### PR TITLE
make changes to load sv_extra in 1.0.0

### DIFF
--- a/nodes/curve/approximate_fourier_curve.py
+++ b/nodes/curve/approximate_fourier_curve.py
@@ -11,7 +11,7 @@ import bpy
 from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, zip_long_repeat, throttle_and_update_node, get_data_nesting_level, ensure_nesting_level, repeat_last_for_length
+from sverchok.data_structure import updateNode, zip_long_repeat, get_data_nesting_level, ensure_nesting_level, repeat_last_for_length
 from sverchok.utils.math import supported_metrics, xyz_metrics
 from sverchok.utils.curve.fourier import SvFourierCurve
 from sverchok.dependencies import scipy

--- a/nodes/curve/fourier_curve.py
+++ b/nodes/curve/fourier_curve.py
@@ -12,7 +12,7 @@ import bpy
 from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, zip_long_repeat, throttle_and_update_node, get_data_nesting_level, ensure_nesting_level, repeat_last_for_length
+from sverchok.data_structure import updateNode, zip_long_repeat, get_data_nesting_level, ensure_nesting_level, repeat_last_for_length
 from sverchok.utils.math import supported_metrics, xyz_metrics
 from sverchok.utils.curve.fourier import SvFourierCurve
 

--- a/nodes/curve/interpolate_fourier_curve.py
+++ b/nodes/curve/interpolate_fourier_curve.py
@@ -12,7 +12,7 @@ import bpy
 from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, zip_long_repeat, throttle_and_update_node, get_data_nesting_level, ensure_nesting_level, repeat_last_for_length
+from sverchok.data_structure import updateNode, zip_long_repeat, get_data_nesting_level, ensure_nesting_level, repeat_last_for_length
 from sverchok.utils.math import supported_metrics, xyz_metrics
 from sverchok.utils.curve.fourier import SvFourierCurve
 

--- a/nodes/curve/intersect_surface_plane.py
+++ b/nodes/curve/intersect_surface_plane.py
@@ -6,7 +6,7 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty, St
 from mathutils import Vector, Matrix
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, zip_long_repeat, match_long_repeat, ensure_nesting_level, throttle_and_update_node
+from sverchok.data_structure import updateNode, zip_long_repeat, match_long_repeat, ensure_nesting_level
 from sverchok.utils.logging import info, exception
 from sverchok.utils.surface import SvSurface
 from sverchok.utils.geom import PlaneEquation
@@ -52,9 +52,9 @@ if skimage is not None or scipy is not None:
                 modes.append(('scipy', "OP + Tangent (Unsorted!)", "Use orthogonal projections + tangent method", 1))
             return modes
 
-        @throttle_and_update_node
         def update_sockets(self, context):
             self.outputs['UVPoints'].hide_safe = self.algorithm != 'skimage'
+            updateNode(self, context)
         
         algorithm : EnumProperty(
                 name = "Algorithm",

--- a/nodes/data/data_item.py
+++ b/nodes/data/data_item.py
@@ -12,7 +12,7 @@ from bpy.types import Operator, Node, PropertyGroup
 from bpy.props import StringProperty, EnumProperty, IntProperty, BoolProperty, FloatProperty, CollectionProperty, PointerProperty, FloatVectorProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, throttle_and_update_node
+from sverchok.data_structure import updateNode
 from sverchok.utils.dictionary import SvDict
 from sverchok.utils.logging import info, debug
 
@@ -100,9 +100,9 @@ class SvDataItemNode(bpy.types.Node, SverchCustomTreeNode):
     #    self.update_keys(None)
     #    self.update_sockets(None)
     
-    @throttle_and_update_node
     def update_sockets_throttled(self, context):
         self.update_sockets(context)
+        updateNode(self, context)
 
     def update_sockets(self, context):
         if not self.inputs['Data'].links:

--- a/nodes/data/spreadsheet.py
+++ b/nodes/data/spreadsheet.py
@@ -22,7 +22,7 @@ import bpy
 from bpy.props import CollectionProperty, EnumProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, match_long_repeat, zip_long_repeat, throttle_and_update_node
+from sverchok.data_structure import updateNode, match_long_repeat, zip_long_repeat
 from sverchok.utils.logging import info, debug
 from sverchok_extra.utils.modules.spreadsheet.ui import *
 
@@ -38,7 +38,6 @@ class SvSpreadsheetNode(bpy.types.Node, SverchCustomTreeNode):
 
     spreadsheet : PointerProperty(type=SvSpreadsheetData)
 
-    @throttle_and_update_node
     def adjust_outputs(self, context):
 
         if self.out_mode == 'ROW':
@@ -71,6 +70,7 @@ class SvSpreadsheetNode(bpy.types.Node, SverchCustomTreeNode):
         self.outputs['Data'].hide_safe = self.out_mode != 'NONE'
         self.outputs['Rows'].hide_safe = self.out_mode != 'NONE'
         self.outputs['Columns'].hide_safe = self.out_mode != 'NONE'
+        updateNode(self, context)
 
     out_modes = [
             ('NONE', "Dictionaries", "Do not display separate outputs", 0),
@@ -127,19 +127,19 @@ class SvSpreadsheetNode(bpy.types.Node, SverchCustomTreeNode):
         formula_cols = self.spreadsheet.get_formula_cols()
         self.inputs['Input'].hide_safe = len(formula_cols) == 0
 
-    @throttle_and_update_node
     def on_update_value(self, context):
         self.adjust_inputs()
+        updateNode(self, context)
 
-    @throttle_and_update_node
     def on_update_row_name(self, context):
         self.adjust_inputs()
         self.adjust_outputs(context)
+        updateNode(self, context)
 
-    @throttle_and_update_node
     def on_update_column(self, context):
         self.adjust_inputs()
         self.adjust_outputs(context)
+        updateNode(self, context)
 
     def check_row_uniq(self):
         row_names = [row.name for row in self.spreadsheet.data]

--- a/nodes/field/vfield_lines_on_surface.py
+++ b/nodes/field/vfield_lines_on_surface.py
@@ -6,7 +6,7 @@ from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 from mathutils import bvhtree
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import updateNode, zip_long_repeat, ensure_nesting_level, throttle_and_update_node
+from sverchok.data_structure import updateNode, zip_long_repeat, ensure_nesting_level
 from sverchok.utils.field.vector import SvVectorField
 from sverchok.utils.surface import SvSurface
 from sverchok.utils.dummy_nodes import add_dummy
@@ -80,11 +80,11 @@ else:
         bl_label = 'Vector Field Lines on Surface'
         bl_icon = 'OUTLINER_OB_EMPTY'
 
-        @throttle_and_update_node
         def update_sockets(self, context):
             self.inputs['MaxT'].hide_safe = self.method == 'EULER'
             self.inputs['Step'].hide_safe = self.method != 'EULER'
             self.inputs['Iterations'].hide_safe = self.method != 'EULER'
+            updateNode(self, context)
 
         methods = [
             ('EULER', "Euler", "Simplest Euler method", 0),

--- a/nodes/solid/solid_waffle.py
+++ b/nodes/solid/solid_waffle.py
@@ -13,7 +13,7 @@ import bpy
 from bpy.props import BoolProperty, FloatProperty, EnumProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import zip_long_repeat, ensure_nesting_level, updateNode, throttle_and_update_node
+from sverchok.data_structure import zip_long_repeat, ensure_nesting_level, updateNode
 from sverchok.utils.curve import SvCurve
 from sverchok.utils.curve.nurbs import SvNurbsCurve
 from sverchok.utils.curve.freecad import SvFreeCadCurve, SvFreeCadNurbsCurve, curve_to_freecad_nurbs
@@ -147,10 +147,10 @@ class SvSolidWaffleNode(bpy.types.Node, SverchCustomTreeNode):
             ('SURFACE', "Surface", "Split along specified surface", 2)
         ]
     
-    @throttle_and_update_node
     def update_sockets(self, context):
         self.inputs['SplitMatrix'].hide_safe = self.split_mode != 'MATRIX'
         self.inputs['SplitSurface'].hide_safe = self.split_mode != 'SURFACE'
+        updateNode(self, context)
 
     split_mode : EnumProperty(
             name = "Split mode",

--- a/nodes/spatial/delaunay_mesh.py
+++ b/nodes/spatial/delaunay_mesh.py
@@ -12,7 +12,7 @@ import bpy
 from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok.data_structure import zip_long_repeat, throttle_and_update_node, repeat_last_for_length, updateNode
+from sverchok.data_structure import zip_long_repeat, repeat_last_for_length, updateNode
 from sverchok.utils.sv_bmesh_utils import bmesh_from_pydata
 from sverchok.utils.mesh_spatial import mesh_insert_verts, find_nearest_idxs
 
@@ -42,9 +42,9 @@ class SvDelaunayOnMeshNode(bpy.types.Node, SverchCustomTreeNode):
         default = True,
         update = updateNode)
 
-    @throttle_and_update_node
     def update_sockets(self, context):
         self.inputs['FaceIndex'].hide_safe = self.mode != 'INDEX'
+        updateNode(self, context)
 
     modes = [
             ('INDEX', "By face index", "Specify index of the face for each vertex being added", 0),

--- a/nodes/surface/triangular_mesh.py
+++ b/nodes/surface/triangular_mesh.py
@@ -4,11 +4,6 @@ import numpy as np
 import bpy
 from bpy.props import FloatProperty, EnumProperty, BoolProperty, IntProperty, StringProperty
 
-
-from sverchok import bl_info
-if bl_info["version"] < (1, 0, 0):
-    from sverchok.core.update_system import process_from_node
-
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode, zip_long_repeat, ensure_nesting_level
 from sverchok.utils.logging import info, exception
@@ -66,12 +61,7 @@ if pygalmesh is not None and scipy is not None:
         def execute(self, context):
             node = bpy.data.node_groups[self.node_tree].nodes[self.node_name]
             node.active = True
-
-            if bl_info["version"] < (1, 0, 0):
-                process_from_node(node)
-            else:
-                node.process_node(None)
-                
+            node.process_node(None)
             node.active = False
             return {'FINISHED'}
 


### PR DESCRIPTION
due to the continuous development of sverchok's own back-end (update system, and math and helper functions) it doesn't make sense to maintain a version of sverchok-extra that will run in both sverchok 0.6.0 and sverchok 1.0.0+. Henceforth this add-on supports only Sverchok 1.0.0+

it is possible to use older versions of this add-on with sverchok 0.6.0, but the attention of devs is now 1.0.0. 
