### PR TITLE
Awkward arrays

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,6 +25,7 @@ if __name__ != "sverchok_extra":
     sys.modules["sverchok_extra"] = sys.modules[__name__]
 
 from sverchok_extra import icons
+from sverchok_extra.utils import array_math
 from sverchok_extra import settings
 from sverchok_extra.utils import show_welcome
 
@@ -118,6 +119,7 @@ def nodes_index():
                 ('array.random_array', 'SvRandomArrayNode'),
                 ('array.py_to_array', 'SvPyToArrayNode'),
                 ('array.arr_vector_in', 'SvArrVectorInNode'),
+                ('array.arr_matrix_in', 'SvArrMatrixInNode'),
                 ('array.arr_polyline', 'SvArrPolylineNode'),
                 None,
                 ('array.arr_math', 'SvArrMathNode'),
@@ -126,24 +128,31 @@ def nodes_index():
                 ('array.arr_resample_polyline', 'SvResamplePolylineNode'),
                 ('array.arr_subdivide_polyline', 'SvArrSubdividePolylineNode'),
                 ('array.arr_vector_math', 'SvArrVectorMathNode'),
+                ('array.arr_rotate_vector', 'SvArrRotateVectorNode'),
                 ('array.move_vertices', 'SvArrMoveVerticesNode'),
+                ('array.arr_vector_noise', 'SvArrVectorNoiseNode'),
                 ('array.matrix_transform', 'SvArrMatrixTransformNode'),
                 ('array.move_mesh_array', 'SvArrMoveMeshNode'),
                 ('array.join_mesh_array', 'SvArrJoinMeshNode'),
                 ('array.flip_mesh_normals_array', 'SvArrFlipMeshNormalsNode'),
-                ('array.vector_interpolation', 'SvArrVectorInterpolationNode'),
                 None,
+                ('array.array_length', 'SvArrayLengthNode'),
+                ('array.run_lengths', 'SvArrRunLengthsNode'),
                 ('array.zip_array', 'SvZipArrayNode'),
+                ('array.set_field', 'SvSetFieldNode'),
                 ('array.unzip_array', 'SvUnzipArrayNode'),
                 ('array.arr_get_item', 'SvArrGetItemNode'),
+                ('array.slice_array', 'SvSliceArrayNode'),
                 ('array.concatenate_arrays', 'SvConcatenateArraysNode'),
                 ('array.to_regular_array', 'SvToRegularArrayNode'),
+                ('array.new_axis', 'SvNewAxisNode'),
                 ('array.unflatten_array', 'SvUnflattenArrayNode'),
                 ('array.unflattening_array', 'SvUnflatteningArrayNode'),
                 ('array.flatten_array', 'SvFlattenArrayNode'),
                 ('array.flattening_array', 'SvFlatteningArrayNode'),
                 ('array.broadcast_arrays', 'SvBroadcastArraysNode'),
                 ('array.where_array', 'SvWhereArrayNode'),
+                ('array.local_index', 'SvLocalIndexNode'),
                 None,
                 ('array.array_to_py', 'SvArrayToPyNode'),
                 ('array.print_array', 'SvPrintArrayNode'),
@@ -213,8 +222,10 @@ def reload_modules():
         debug("Reloading: %s", im)
         importlib.reload(im)
 
-    from sverchok_extra.utils import array_math
-    importlib.reload(array_math)
+    util_modules = [m for p, m in sys.modules.items()
+                    if p.startswith('sverchok_extra.utils')]
+    for module in util_modules:
+        importlib.reload(module)
 
 
 if reload_event:

--- a/__init__.py
+++ b/__init__.py
@@ -109,7 +109,45 @@ def nodes_index():
             ]),
             ("API", [
                 ('exchange.api_in', 'SvExApiInNode'),
-                ('exchange.api_out', 'SvExApiOutNode')
+                ('exchange.api_out', 'SvExApiOutNode'),
+            ]),
+            ('Array', [
+                ('array.input_value', 'SvInputValueNode'),
+                ('array.input_array', 'SvInputArrayNode'),
+                ('array.arr_number_range', 'SvArrNumberRangeNode'),
+                ('array.random_array', 'SvRandomArrayNode'),
+                ('array.py_to_array', 'SvPyToArrayNode'),
+                ('array.arr_vector_in', 'SvArrVectorInNode'),
+                ('array.arr_polyline', 'SvArrPolylineNode'),
+                None,
+                ('array.arr_math', 'SvArrMathNode'),
+                ('array.bridge_polylines', 'SvArrBridgePolylinesNode'),
+                ('array.arr_polyline_length', 'SvArrPolylineLengthNode'),
+                ('array.arr_resample_polyline', 'SvResamplePolylineNode'),
+                ('array.arr_subdivide_polyline', 'SvArrSubdividePolylineNode'),
+                ('array.arr_vector_math', 'SvArrVectorMathNode'),
+                ('array.move_vertices', 'SvArrMoveVerticesNode'),
+                ('array.matrix_transform', 'SvArrMatrixTransformNode'),
+                ('array.move_mesh_array', 'SvArrMoveMeshNode'),
+                ('array.join_mesh_array', 'SvArrJoinMeshNode'),
+                ('array.flip_mesh_normals_array', 'SvArrFlipMeshNormalsNode'),
+                ('array.vector_interpolation', 'SvArrVectorInterpolationNode'),
+                None,
+                ('array.zip_array', 'SvZipArrayNode'),
+                ('array.unzip_array', 'SvUnzipArrayNode'),
+                ('array.arr_get_item', 'SvArrGetItemNode'),
+                ('array.concatenate_arrays', 'SvConcatenateArraysNode'),
+                ('array.to_regular_array', 'SvToRegularArrayNode'),
+                ('array.unflatten_array', 'SvUnflattenArrayNode'),
+                ('array.unflattening_array', 'SvUnflatteningArrayNode'),
+                ('array.flatten_array', 'SvFlattenArrayNode'),
+                ('array.flattening_array', 'SvFlatteningArrayNode'),
+                ('array.broadcast_arrays', 'SvBroadcastArraysNode'),
+                ('array.where_array', 'SvWhereArrayNode'),
+                None,
+                ('array.array_to_py', 'SvArrayToPyNode'),
+                ('array.print_array', 'SvPrintArrayNode'),
+                ('array.array_viewer', 'SvArrMeshViewerNode'),
             ])
     ]
 
@@ -174,6 +212,14 @@ def reload_modules():
     for im in imported_modules:
         debug("Reloading: %s", im)
         importlib.reload(im)
+
+    from sverchok_extra.utils import array_math
+    importlib.reload(array_math)
+
+
+if reload_event:
+    reload_modules()
+
 
 def register():
     global our_menu_classes

--- a/nodes/array/arr_get_item.py
+++ b/nodes/array/arr_get_item.py
@@ -1,0 +1,51 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrGetItemNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrGetItemNode'
+    bl_label = 'Get Item (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        s = self.inputs.new('SvStringsSocket', 'Index')
+        s.use_prop = True
+        s.default_property_type = 'int'
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in_s = self.inputs[0]
+        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            return
+        where = self.inputs[1].sv_get(deepcopy=False)
+        where = where if self.inputs[1].is_linked else where[0]
+        data = data[where]
+        self.outputs[0].sv_set(data)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrGetItemNode])

--- a/nodes/array/arr_math.py
+++ b/nodes/array/arr_math.py
@@ -1,0 +1,80 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrMathNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrMathNode'
+    bl_label = 'Math (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    functions = [
+        ("", "Function", "", 0),
+        ("ADD", "Add", "", 1),
+        ("SUBTRACT", "Subtract", "", 2),
+        ("MULTIPLY", "Multiply", "", 3),
+        ("DIVIDE", "Divide", "", 4),
+        ("", "Trigonometry", "", 5),
+        ("SIN", "Sine", "", 6),
+        ("COS", "Cosine", "", 7),
+    ]
+
+    func_code = {
+        'ADD': lambda x, y: x+y,
+        'SUBTRACT': lambda x, y: x-y,
+        'MULTIPLY': lambda x, y: x*y,
+        'DIVIDE': lambda x, y: x/y,
+        'SIN': lambda x, y: np.sin(x),
+        'COS': lambda x, y: np.cos(x),
+    }
+
+    def update_function(self, context):
+        num = 1 if self.function in {'SIN', 'COS'} else 2
+        self.inputs[1].enabled = num > 1
+        self.process_node(context)
+
+    function: EnumProperty(items=functions,
+                           default='ADD',
+                           update=update_function)
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, "function", text="")
+
+    def sv_init(self, context):
+        s = self.inputs.new('SvStringsSocket', "Data")
+        s.use_prop = True
+        s.show_property_type = True
+        s = self.inputs.new('SvStringsSocket', "Data")
+        s.use_prop = True
+        s.show_property_type = True
+
+        self.outputs.new('SvStringsSocket', "Data")
+
+    def process(self):
+        x = self.inputs[0].sv_get(deepcopy=False)
+        x = x if self.inputs[0].is_linked else x[0][0]
+        y = self.inputs[1].sv_get(deepcopy=False)
+        y = y if self.inputs[1].is_linked else y[0][0]
+        self.outputs[0].sv_set(self.func_code[self.function](x, y))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrMathNode])

--- a/nodes/array/arr_matrix_in.py
+++ b/nodes/array/arr_matrix_in.py
@@ -1,0 +1,44 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok_extra.utils import array_math as amath
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvArrMatrixInNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrMatrixInNode'
+    bl_label = 'Matrix in (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Position').use_prop = True
+        s = self.inputs.new('SvVerticesSocket', 'Scale')
+        s.use_prop = True
+        s.default_property = 1, 1, 1
+        self.outputs.new('SvMatrixSocket', 'Matrix')
+
+    def process(self):
+        pos = self.inputs[0].sv_get(deepcopy=False)
+        pos = pos if self.inputs[0].is_linked else ak.Array([list(pos[0][0])])
+        scale = self.inputs[1].sv_get(deepcopy=False)
+        scale = scale if self.inputs[1].is_linked else ak.Array([list(scale[0][0])])
+        self.outputs[0].sv_set(amath.matrix(pos, scale))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrMatrixInNode])

--- a/nodes/array/arr_number_range.py
+++ b/nodes/array/arr_number_range.py
@@ -1,0 +1,248 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bpy
+from bpy.props import EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.data_structure import numpy_match_long_repeat
+import numpy as np
+
+try:
+    import awkward as ak
+    # import numba as nb
+    nb = None
+except ImportError:
+    ak, nb = None, None
+
+if nb:
+    # @nb.jit(nopython=True)
+    # def arange(start, stop, step, builder):
+    #     for i in range(len(start)):
+    #         num = int((stop[i] - start[i]) // step[i])
+    #         builder.begin_list()
+    #         for j in range(num):
+    #             inc = j * step[i]
+    #             builder.append(start[i] + inc)
+    #         builder.end_list()
+    #
+    #
+    # def _range_step_stop(start, stop, step):
+    #     start, stop, step = np.asarray(start), np.asarray(stop), np.asarray(step)
+    #     start, stop, step = numpy_match_long_repeat([start, stop, step])
+    #     build = ak.ArrayBuilder()
+    #     arange(start, stop, step, build)
+    #     return build.snapshot()
+
+    #
+    # @nb.jit(nopython=True)
+    # def arange(start, stop, step):
+    #     inp_num = max(len(start), len(stop), len(step))
+    #     nums = np.zeros(inp_num+1, dtype=np.int64)
+    #     max1, max2, max3 = len(start)-1, len(stop)-1, len(step)-1
+    #     for i in range(inp_num):
+    #         start_ = start[i] if i <= max1 else start[max1]
+    #         stop_ = stop[i] if i <= max2 else stop[max2]
+    #         step_ = step[i] if i <= max3 else step[max3]
+    #         increment = int((stop_ - start_) // step_)
+    #         nums[i+1] = increment
+    #     res = np.zeros(np.sum(nums))
+    #     current = 0
+    #     for i in range(inp_num):
+    #         n = nums[i+1]
+    #         start_ = start[i] if i <= max1 else start[max1]
+    #         step_ = step[i] if i <= max3 else step[max3]
+    #         for j in range(n):
+    #             res[current] = start_ + (j * step_)
+    #             current += 1
+    #     return res, np.cumsum(nums)
+    #
+    #
+    # def _range_step_stop(start, stop, step):
+    #     start, stop, step = np.asarray(start), np.asarray(stop), np.asarray(step)
+    #     res, ind = arange(start, stop, step)
+    #     res = ak.contents.NumpyArray(res)
+    #     ind = ak.index.Index(ind)
+    #     ar = ak.contents.ListOffsetArray(ind, res)
+    #     return ak.Array(ar)
+
+
+    @nb.jit(nopython=True)
+    def arange(start, stop, step):
+        inp_num = len(start)
+        nums = np.zeros(inp_num+1, dtype=np.int64)
+        for i in range(inp_num):
+            increment = int((stop[i] - start[i]) // step[i])
+            nums[i+1] = increment
+        res = np.zeros(np.sum(nums))
+        current = 0
+        for i in range(inp_num):
+            n = nums[i+1]
+            for j in range(n):
+                res[current] = start[i] + (j * step[i])
+                current += 1
+        return res, np.cumsum(nums)
+
+
+def _range_(start, stop, step, type_='FLOAT'):
+    if all(isinstance(v, (float, int)) for v in (start, stop, step)):
+        step = max(1e-5, abs(step))
+        if start > stop:
+            step = -step
+        ar = np.arange(start, stop, step)
+    else:
+        args = [start, stop, step]
+        args = [[v] if isinstance(v, (float, int)) else v for v in args]
+        args = [np.asarray(v) for v in args]
+        start, stop, step = numpy_match_long_repeat(args)
+        res, ind = arange(start, stop, step)
+        if type_ == 'INT':
+            res = np.asarray(res, dtype=np.int)
+        res = ak.contents.NumpyArray(res)
+        ind = ak.index.Index(ind)
+        ar = ak.contents.ListOffsetArray(ind, res)
+    return ak.Array(ar)
+
+
+def range_(start, stop, step, type_):
+    if not all(isinstance(v, (int, float)) for v in [start, stop, step]):
+        start, stop, step = ak.broadcast_arrays(start, stop, step)
+        step = np.absolute(step)
+        step = ak.where(step < 1e-5, 1e-5, step)
+        step = ak.where(start > stop, -step, step)
+        count = (stop - start) / step
+        count = ak.where(count < 0, 0, count)
+        count = ak.values_astype(count, int)
+        num = ak.sum(count)
+        out = np.zeros(num)
+        out = ak.unflatten(out, count)
+        indexes = ak.local_index(out)
+        steps = step * indexes
+        return ak.values_astype(out + steps + start, type_)
+    else:
+        step = max(1e-5, abs(step))
+        step = -step if start > stop else step
+        return ak.Array(np.arange(start, stop, step, dtype=type_))
+
+
+def count_range(start, stop, count, type_):
+    if not all(isinstance(v, (int, float)) for v in [start, stop, count]):
+        start, stop, count = ak.broadcast_arrays(start, stop, count)
+        num = ak.sum(count)
+        out = np.zeros(num)
+        out = ak.unflatten(out, count)
+        indexes = ak.local_index(out)
+        diff = stop - start
+        step = diff / ak.where(count == 1, 1, (count - 1))
+        steps = step * indexes
+        return ak.values_astype(out + steps + start, type_)
+    else:
+        return ak.Array(np.linspace(start, stop, num=count, dtype=type_))
+
+
+def step_range(start, step, count, type_):
+    if not all(isinstance(v, (int, float)) for v in [start, step, count]):
+        start, step, count = ak.broadcast_arrays(start, step, count)
+        num = ak.sum(count)
+        out = np.zeros(num)
+        out = ak.unflatten(out, count)
+        indexes = ak.local_index(out)
+        steps = step * indexes
+        return ak.values_astype(out + steps + start, type_)
+    else:
+        stop = start + step * (count - 1)
+        return ak.Array(np.linspace(start, stop, num=int(count), dtype=type_))
+
+
+class SvArrNumberRangeNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrNumberRangeNode'
+    bl_label = 'Range Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    type_modes = [
+        ("INT", "Int", "Integer Series", 0),
+        ("FLOAT", "Float", "Float Series", 1),
+    ]
+
+    range_modes = [
+        ("RANGE", "Range", "Define range by setting start, step and stop.", 0),
+        ("COUNT", "Count", "Define range by setting start, stop and count number (divisions).", 1),
+        ("STEP", "Step", "Define range by setting start, step and count number", 2),
+    ]
+
+    def mode_change(self, context):
+        sock_type = 'int' if self.type_mode == 'INT' else 'float'
+        self.inputs['Start'].default_property_type = sock_type
+        self.inputs['Stop'].default_property_type = sock_type
+        self.inputs['Step'].default_property_type = sock_type
+
+        self.inputs['Stop'].enabled = self.range_mode != 'STEP'
+        self.inputs['Step'].enabled = self.range_mode != 'COUNT'
+        self.inputs['Count'].enabled = self.range_mode != 'RANGE'
+        self.process_node(context)
+
+    type_mode: EnumProperty(
+        name='Number Type',
+        items=type_modes,
+        default='FLOAT',
+        update=mode_change)
+
+    range_mode: EnumProperty(
+        name='Range Mode',
+        items=range_modes,
+        default='RANGE',
+        update=mode_change)
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', "Start").use_prop = True
+        s = self.inputs.new('SvStringsSocket', "Stop")
+        s.use_prop = True
+        s.default_float_property = 10
+        s.default_int_property = 10
+        s = self.inputs.new('SvStringsSocket', "Step")
+        s.use_prop = True
+        s.default_float_property = 1
+        s.default_int_property = 1
+        s = self.inputs.new('SvStringsSocket', "Count")
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.default_int_property = 10
+        s.enabled = False
+
+        self.outputs.new('SvStringsSocket', "Range")
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, "type_mode", expand=True)
+        layout.prop(self, "range_mode", expand=True)
+
+    def process(self):
+        start = self.inputs['Start'].sv_get(deepcopy=False)
+        start = start if self.inputs['Start'].is_linked else start[0][0]
+        stop = self.inputs['Stop'].sv_get(deepcopy=False)
+        stop = stop if self.inputs['Stop'].is_linked else stop[0][0]
+        step = self.inputs['Step'].sv_get(deepcopy=False)
+        step = step if self.inputs['Step'].is_linked else step[0][0]
+        count = self.inputs['Count'].sv_get(deepcopy=False)
+        count = count if self.inputs['Count'].is_linked else count[0][0]
+        type_ = int if self.type_mode == 'INT' else float
+        if self.range_mode == 'RANGE':
+            res = range_(start, stop, step, type_)
+        elif self.range_mode == 'COUNT':
+            res = count_range(start, stop, count, type_)
+        elif self.range_mode == 'STEP':
+            res = step_range(start, step, count, type_)
+        else:
+            raise(TypeError(f"Unknown type {self.range_mode=}"))
+        self.outputs[0].sv_set(res)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrNumberRangeNode])

--- a/nodes/array/arr_polyline.py
+++ b/nodes/array/arr_polyline.py
@@ -1,0 +1,50 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrPolylineNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrPolylineNode'
+    bl_label = 'Polyline (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vertices')
+        self.outputs.new('SvStringsSocket', 'Array')
+
+    def process(self):
+        verts = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if verts is None:
+            return
+        _, edge_shape = ak.broadcast_arrays(verts, 0, depth_limit=verts.ndim-1)  # if cycle
+        if verts.ndim == edge_shape.ndim:  # if verts are regular the broadcast is different
+            edge_shape = ak.flatten(edge_shape, axis=-1)
+        edge_shape = edge_shape[..., :-1]  # if not cycle
+        edge_indexes = ak.local_index(edge_shape)
+        edge_wrap_ind = edge_indexes[..., np.newaxis]
+        edges = ak.concatenate([edge_wrap_ind, edge_wrap_ind+1], axis=-1)
+        if verts.ndim == 2:
+            verts, edges = verts[np.newaxis], edges[np.newaxis]
+        polyline = ak.Array({'verts': verts, 'edges': edges})
+        self.outputs[0].sv_set(polyline)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrPolylineNode])

--- a/nodes/array/arr_polyline_length.py
+++ b/nodes/array/arr_polyline_length.py
@@ -1,0 +1,46 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrPolylineLengthNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrPolylineLengthNode'
+    bl_label = 'Polyline Length (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        self.outputs.new('SvStringsSocket', 'Line Length')
+        self.outputs.new('SvStringsSocket', 'Segment Length')
+
+    def process(self):
+        line = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if line is None:
+            return
+        vert1 = line.verts[..., :-1, :]
+        vert2 = line.verts[..., 1:, :]
+        dist_vec = vert2 - vert1
+        segment_len = ak.sum(dist_vec**2, axis=-1)**0.5
+        line_len = ak.sum(segment_len, axis=-1)
+        self.outputs['Line Length'].sv_set(line_len)
+        self.outputs['Segment Length'].sv_set(segment_len)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrPolylineLengthNode])

--- a/nodes/array/arr_resample_polyline.py
+++ b/nodes/array/arr_resample_polyline.py
@@ -1,0 +1,57 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+import numpy as np
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok_extra.utils import array_math as amath
+
+
+class SvResamplePolylineNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvResamplePolylineNode'
+    bl_label = 'Resample Polyline (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        s = self.inputs.new('SvStringsSocket', 'Count')
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.default_int_property = 10
+        self.outputs.new('SvStringsSocket', 'Array')
+
+    def process(self):
+        line = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if line is None:
+            return
+        count = self.inputs[1].sv_get(deepcopy=False)
+        count = count if self.inputs[1].is_linked else ak.Array(count[0])
+        segment_len = amath.segment_length(line.verts)
+        line_len = ak.sum(segment_len, axis=-1)
+        step = line_len / count
+        segment_count = ak.values_astype(segment_len / step, int)
+        total_num = ak.sum(count)
+        new_verts = np.zeros((total_num, 3))
+        new_verts = ak.unflatten(new_verts, count)
+        vert1 = line.verts[..., :-1, :]
+        vert2 = line.verts[..., 1:, :]
+        breakpoint()
+        self.outputs[0].sv_set(line)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvResamplePolylineNode])

--- a/nodes/array/arr_rotate_vector.py
+++ b/nodes/array/arr_rotate_vector.py
@@ -1,0 +1,44 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok_extra.utils import array_math as amath
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvArrRotateVectorNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrRotateVectorNode'
+    bl_label = 'Rotate Vector (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vector').use_prop = True
+        self.inputs.new('SvVerticesSocket', 'Rotation').use_prop = True
+        self.outputs.new('SvVerticesSocket', 'Vector')
+
+    def process(self):
+        verts = self.inputs[0].sv_get(deepcopy=False)
+        verts = verts if self.inputs[0].is_linked else ak.Array([list(verts[0][0])])
+        euler = self.inputs[1].sv_get(deepcopy=False)
+        euler = euler if self.inputs[1].is_linked else ak.Array([list(euler[0][0])])
+        m = amath.euler_to_matrix(euler)
+        new_verts = amath.apply_matrix_3x3(verts, m)
+        self.outputs[0].sv_set(new_verts)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrRotateVectorNode])

--- a/nodes/array/arr_subdivide_polyline.py
+++ b/nodes/array/arr_subdivide_polyline.py
@@ -54,10 +54,12 @@ class SvArrSubdividePolylineNode(SverchCustomTreeNode, bpy.types.Node):
         if line is None:
             return
         cuts = self.inputs[1].sv_get(deepcopy=False)
-        cuts = cuts if self.inputs[1].is_linked else ak.Array(cuts[0])
+        cuts = ak.values_astype(cuts, int) if self.inputs[1].is_linked \
+            else ak.Array([max(cuts[0]+[0])])
 
         new_verts = amath.subdivide_polyline(line.verts, cuts, self.interpolation)
-        new_line = ak.Array({'verts': new_verts})
+        new_edges = amath.connect_polyline(new_verts)
+        new_line = ak.Array({'verts': new_verts, 'edges': new_edges})
         self.outputs[0].sv_set(new_line)
 
 

--- a/nodes/array/arr_subdivide_polyline.py
+++ b/nodes/array/arr_subdivide_polyline.py
@@ -1,0 +1,64 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bpy
+from bpy.props import EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.profile import profile
+from sverchok_extra.utils import array_math as amath
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvArrSubdividePolylineNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrSubdividePolylineNode'
+    bl_label = 'Subdivide Polyline (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    interpolations = [
+        ('LINEAR', 'Linear', '', 0),
+        ('CUBIC', 'Cubic', '', 1),
+        ('CATMULL_ROM', 'Catmull-Rom', '', 2),
+    ]
+
+    interpolation: EnumProperty(items=interpolations,
+                                update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'interpolation', text='')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        s = self.inputs.new('SvStringsSocket', 'Cuts')
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.default_int_property = 10
+        self.outputs.new('SvStringsSocket', 'Array')
+
+    @profile
+    def process(self):
+        line = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if line is None:
+            return
+        cuts = self.inputs[1].sv_get(deepcopy=False)
+        cuts = cuts if self.inputs[1].is_linked else ak.Array(cuts[0])
+
+        new_verts = amath.subdivide_polyline(line.verts, cuts, self.interpolation)
+        new_line = ak.Array({'verts': new_verts})
+        self.outputs[0].sv_set(new_line)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrSubdividePolylineNode])

--- a/nodes/array/arr_vector_in.py
+++ b/nodes/array/arr_vector_in.py
@@ -1,0 +1,51 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+import numpy as np
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrVectorInNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrVectorInNode'
+    bl_label = 'Vector in (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', "X").use_prop = True
+        self.inputs.new('SvStringsSocket', "Y").use_prop = True
+        self.inputs.new('SvStringsSocket', "Z").use_prop = True
+        self.outputs.new('SvVerticesSocket', "Vectors")
+
+    def process(self):
+        x = self.inputs[0].sv_get(deepcopy=False)
+        x = x[..., np.newaxis] if self.inputs[0].is_linked else x[0][0]
+        y = self.inputs[1].sv_get(deepcopy=False)
+        y = y[..., np.newaxis] if self.inputs[1].is_linked else y[0][0]
+        z = self.inputs[2].sv_get(deepcopy=False)
+        z = z[..., np.newaxis] if self.inputs[2].is_linked else z[0][0]
+        if not any(s.is_linked for s in self.inputs):
+            self.outputs[0].sv_set(ak.Array([x, y, z]))
+            return
+        x, y, z = ak.broadcast_arrays(x, y, z)
+        # out = np.column_stack([x, y, z])
+        out = ak.concatenate([x, y, z], axis=-1)
+        self.outputs[0].sv_set(out)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrVectorInNode])

--- a/nodes/array/arr_vector_in.py
+++ b/nodes/array/arr_vector_in.py
@@ -31,14 +31,18 @@ class SvArrVectorInNode(SverchCustomTreeNode, bpy.types.Node):
         self.inputs.new('SvStringsSocket', "Y").use_prop = True
         self.inputs.new('SvStringsSocket', "Z").use_prop = True
         self.outputs.new('SvVerticesSocket', "Vectors")
+        self.width = 100
 
     def process(self):
         x = self.inputs[0].sv_get(deepcopy=False)
-        x = x[..., np.newaxis] if self.inputs[0].is_linked else x[0][0]
+        x = x if self.inputs[0].is_linked else x[0][0]
+        x = x[..., np.newaxis] if hasattr(x, '__len__') else x
         y = self.inputs[1].sv_get(deepcopy=False)
-        y = y[..., np.newaxis] if self.inputs[1].is_linked else y[0][0]
+        y = y if self.inputs[1].is_linked else y[0][0]
+        y = y[..., np.newaxis] if hasattr(y, '__len__') else y
         z = self.inputs[2].sv_get(deepcopy=False)
-        z = z[..., np.newaxis] if self.inputs[2].is_linked else z[0][0]
+        z = z if self.inputs[2].is_linked else z[0][0]
+        z = z[..., np.newaxis] if hasattr(z, '__len__') else z
         if not any(s.is_linked for s in self.inputs):
             self.outputs[0].sv_set(ak.Array([x, y, z]))
             return

--- a/nodes/array/arr_vector_math.py
+++ b/nodes/array/arr_vector_math.py
@@ -81,6 +81,7 @@ class SvArrVectorMathNode(SverchCustomTreeNode, bpy.types.Node):
     def process(self):
         x = self.inputs[0].sv_get(deepcopy=False)
         x = x if self.inputs[0].is_linked else ak.Array(x[0][0])
+        x = x.verts if hasattr(x, 'fields') and 'verts' in x.fields else x
         y = self.inputs[1].sv_get(deepcopy=False)
         y = y if self.inputs[1].is_linked else ak.Array(y[0][0])
         z = self.inputs[2].sv_get(deepcopy=False)

--- a/nodes/array/arr_vector_math.py
+++ b/nodes/array/arr_vector_math.py
@@ -1,0 +1,92 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+import numpy as np
+
+import bpy
+from bpy.props import EnumProperty
+
+from sverchok_extra.utils.array_math import scale_vert
+from sverchok.node_tree import SverchCustomTreeNode
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvArrVectorMathNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrVectorMathNode'
+    bl_label = 'Vector Math (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    functions = [
+        ("ADD", "Add", "", 0),
+        ("SUBTRACT", "Subtract", "", 1),
+        ("MULTIPLY", "Multiply", "", 2),
+        ("DIVIDE", "Divide", "", 3),
+        ("", "", "", 4),
+        ("LEN", "Length", "", 5),
+        ("", "", "", 6),
+        ("NORMALIZE", "Normalize", "", 7),
+        ("SCALE", "Scale", "", 8),
+    ]
+
+    func_code = {
+        'ADD': lambda x, y: x + y,
+        'SUBTRACT': lambda x, y: x - y,
+        'MULTIPLY': lambda x, y: x * y,
+        'DIVIDE': lambda x, y: x / y,
+        'LEN': lambda x, y: ak.sum(x**2, axis=-1)**0.5,
+        'NORMALIZE': lambda x, y: x / (ak.sum(x**2, axis=-1)**0.5)[..., np.newaxis],
+        'SCALE': scale_vert,
+    }
+
+    def update_function(self, context):
+        num = 1 if self.function in {'LEN'} else 2
+        self.inputs[1].enabled = num > 1
+
+        show_value = self.function in {'SCALE'}
+        self.inputs[1].enabled = not show_value
+        self.inputs[2].enabled = show_value
+
+        out_t = 'SvStringsSocket' if self.function in {'LEN'} else 'SvVerticesSocket'
+        if self.outputs[0].bl_idname != out_t:
+            self.outputs[0].replace_socket(out_t)
+        self.process_node(context)
+
+    function: EnumProperty(items=functions,
+                           default='ADD',
+                           update=update_function)
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, "function", text="")
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vector').use_prop = True
+        self.inputs.new('SvVerticesSocket', 'Vector').use_prop = True
+        s = self.inputs.new('SvStringsSocket', 'Value')
+        s.use_prop = True
+        s.enabled = False
+        self.outputs.new('SvVerticesSocket', 'Data')
+
+    def process(self):
+        x = self.inputs[0].sv_get(deepcopy=False)
+        x = x if self.inputs[0].is_linked else ak.Array(x[0][0])
+        y = self.inputs[1].sv_get(deepcopy=False)
+        y = y if self.inputs[1].is_linked else ak.Array(y[0][0])
+        z = self.inputs[2].sv_get(deepcopy=False)
+        z = z if self.inputs[2].is_linked else ak.Array(z[0])
+        y = z if self.function in {'SCALE'} else y
+        self.outputs[0].sv_set(self.func_code[self.function](x, y))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrVectorMathNode])

--- a/nodes/array/arr_vector_noise.py
+++ b/nodes/array/arr_vector_noise.py
@@ -1,0 +1,66 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+
+import bpy
+from bpy.props import IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.profile import profile
+from sverchok.utils.sv_noise_utils import numpy_perlin_noise
+
+from sverchok_extra.utils import array_math as amath
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvArrVectorNoiseNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrVectorNoiseNode'
+    bl_label = 'Vector Noise (Array)'
+    sv_icon = 'SV_ALPHA'
+
+    seed: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'seed')
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vertices')
+        s = self.inputs.new('SvStringsSocket', 'Scale')
+        s.use_prop = True
+        s.default_float_property = 1.0
+        self.outputs.new('SvVerticesSocket', 'Noise')
+
+    @profile
+    def process(self):
+        verts = self.inputs['Vertices'].sv_get(deepcopy=False, default=None)
+        if verts is None:
+            return
+        scale = self.inputs['Scale'].sv_get(deepcopy=False)
+        scale = scale if self.inputs['Scale'].is_linked else scale[0][0]
+
+        sc_verts1 = verts * scale
+        sc_verts2, counts = amath.flatten(sc_verts1, deep=-2)
+        sc_verts = ak.to_numpy(sc_verts2)
+        noise = np.stack((
+            numpy_perlin_noise(sc_verts, self.seed, smooth=True),
+            numpy_perlin_noise(sc_verts, self.seed + 1, smooth=True),
+            numpy_perlin_noise(sc_verts, self.seed + 2, smooth=True)
+        )).T
+        noise = amath.unflatten(noise, counts)
+        self.outputs[0].sv_set(noise)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrVectorNoiseNode])

--- a/nodes/array/array_length.py
+++ b/nodes/array/array_length.py
@@ -9,7 +9,6 @@ import bpy
 from bpy.props import IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok_extra.utils import array_math as amath
 
 try:
     import awkward as ak
@@ -17,13 +16,13 @@ except ImportError:
     ak = None
 
 
-class SvArrGetItemNode(SverchCustomTreeNode, bpy.types.Node):
+class SvArrayLengthNode(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: array
     Tooltip:
     """
-    bl_idname = 'SvArrGetItemNode'
-    bl_label = 'Get Item (Array)'
+    bl_idname = 'SvArrayLengthNode'
+    bl_label = 'Array Length'
     sv_icon = 'SV_ALPHA'
     sv_dependencies = ['awkward']
 
@@ -34,25 +33,14 @@ class SvArrGetItemNode(SverchCustomTreeNode, bpy.types.Node):
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', 'Data')
-        s = self.inputs.new('SvStringsSocket', 'Index')
-        s.use_prop = True
-        s.default_property_type = 'int'
         self.outputs.new('SvStringsSocket', 'Data')
-
-    def sv_update(self):
-        in_s = self.inputs[0]
-        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
-        if self.outputs[0].bl_idname != out_type:
-            self.outputs[0].replace_socket(out_type)
 
     def process(self):
         data = self.inputs[0].sv_get(deepcopy=False, default=None)
         if data is None:
             return
-        where = self.inputs[1].sv_get(deepcopy=False)
-        where = where if self.inputs[1].is_linked else where[0][0]
-        data = data[amath.slices(where, axis=self.axis)]
-        self.outputs[0].sv_set(data)
+        lens = ak.num(data, axis=self.axis)
+        self.outputs[0].sv_set(lens)
 
 
-register, unregister = bpy.utils.register_classes_factory([SvArrGetItemNode])
+register, unregister = bpy.utils.register_classes_factory([SvArrayLengthNode])

--- a/nodes/array/array_to_py.py
+++ b/nodes/array/array_to_py.py
@@ -1,0 +1,52 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import BoolProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrayToPyNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrayToPyNode'
+    bl_label = 'Array to Python'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    to_numpy: BoolProperty()
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'to_numpy')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in_s = self.inputs[0]
+        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=[])
+        if self.to_numpy:
+            self.outputs[0].sv_set(ak.to_numpy(data))
+        else:
+            self.outputs[0].sv_set(ak.to_list(data))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrayToPyNode])

--- a/nodes/array/array_viewer.py
+++ b/nodes/array/array_viewer.py
@@ -1,0 +1,107 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+from itertools import cycle
+
+from sverchok.utils.handle_blender_data import correct_collection_length
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.utils.nodes_mixins.generating_objects import SvViewerLightNode, SvMeshData
+
+
+class SvArrMeshViewerNode(
+    SvViewerLightNode, SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrMeshViewerNode'
+    bl_label = 'Mesh Viewer (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    mesh_data: bpy.props.CollectionProperty(type=SvMeshData, options={'SKIP_SAVE'})
+    fast_mesh_update: bpy.props.BoolProperty(
+        default=True,
+        update=lambda s, c: s.process_node(c),
+        description="Usually should be enabled. If some glitches with"
+                    " mesh update, switch it off")
+
+    def sv_draw_buttons(self, context, layout):
+        self.draw_viewer_properties(layout)
+
+    def draw_buttons_fly(self, layout):
+        super().draw_buttons_fly(layout)
+        col = layout.column()
+        col.prop(self, 'fast_mesh_update')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        self.init_viewer()
+
+    def sv_copy(self, other):
+        super().sv_copy(other)
+        self.mesh_data.clear()
+
+    def sv_free(self):
+        for data in self.mesh_data:
+            data.remove_data()
+        super().sv_free()
+
+    def bake(self):
+        for obj_d, me_d in zip(self.object_data, self.mesh_data):
+            obj = obj_d.copy()
+            me = me_d.copy()
+            obj.data = me
+
+    def process(self):
+        mesh = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if not self.is_active or mesh is None:
+            return
+
+        # regenerate mesh data blocks
+        if mesh.verts.ndim == 2:
+            verts = mesh.verts.to_numpy()
+            edges = mesh.edges.to_list() if 'edges' in mesh.fields else []
+            faces = mesh.faces.to_list() if 'faces' in mesh.fields else []
+            correct_collection_length(self.mesh_data, 1)
+            self.mesh_data[0].regenerate_mesh(
+                self.base_data_name,
+                verts,
+                edges,
+                faces,
+                make_changes_test=self.fast_mesh_update)
+        elif mesh.verts.ndim == 3:
+            verts = mesh.verts
+            edges = mesh.edges.to_list() if 'edges' in mesh.fields else [[]]
+            faces = mesh.faces.to_list() if 'faces' in mesh.fields else [[]]
+            obj_num = len(mesh)
+            correct_collection_length(self.mesh_data, obj_num)
+            create_mesh_data = zip(self.mesh_data, cycle(verts), cycle(edges), cycle(faces))
+            for me_data, v, e, f in create_mesh_data:
+                me_data.regenerate_mesh(
+                    self.base_data_name, v.to_numpy(), e, f, make_changes_test=self.fast_mesh_update)
+        else:
+            raise ValueError(f"Vertices dimensions should 2 or 3, {mesh.verts.ndim} is given")
+
+        # regenerate object data blocks
+        # tree.sv_show triggers scene update so the tree attribute also should
+        # be taken into account
+        self.regenerate_objects([self.base_data_name],
+                                [d.mesh for d in self.mesh_data],
+                                to_show=[self.id_data.sv_show and self.show_objects])
+        objs = [obj_data.obj for obj_data in self.object_data]
+        self.outputs[0].sv_set(objs)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrMeshViewerNode])

--- a/nodes/array/bridge_polylines.py
+++ b/nodes/array/bridge_polylines.py
@@ -1,0 +1,53 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrBridgePolylinesNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrBridgePolylinesNode'
+    bl_label = 'Bridge Polylines (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        self.outputs.new('SvStringsSocket', 'Array')
+
+    def process(self):
+        line = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if line is None:
+            return
+        verts = line.verts
+        points_num = ak.num(verts, axis=-2)[..., 0]
+        lines_num = ak.num(verts, axis=-3)
+        line_index = ak.local_index(line.edges, axis=-3)
+        new_edges = line.edges + line_index * points_num
+        edge1 = new_edges[..., :-1, :, :]
+        edge2 = new_edges[..., 1:, :, :][..., ::-1]
+        faces = ak.concatenate([edge1, edge2], axis=-1)
+        faces = ak.flatten(faces, axis=-2)
+        verts = ak.flatten(verts, axis=-2)
+        if verts.ndim == 2:
+            verts, faces = verts[np.newaxis], faces[np.newaxis]
+        polyline = ak.Array({'verts': verts, 'faces': faces})
+        self.outputs[0].sv_set(polyline)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrBridgePolylinesNode])

--- a/nodes/array/broadcast_arrays.py
+++ b/nodes/array/broadcast_arrays.py
@@ -1,0 +1,83 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+from itertools import takewhile
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty, EnumProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvBroadcastArraysNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvBroadcastArraysNode'
+    bl_label = 'Broadcast arrays'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    broadcust_rules = [
+        ("one_to_one", "One to One", "", 0),
+        ("intersect", "Intersect", "", 1),
+        ("all_or_nothing", "All or Nothing", "", 2),
+        ("none", "None", "", 3),
+    ]
+
+    broadcust_rule: EnumProperty(items=broadcust_rules,
+                                 update=lambda s, c: s.process_node(c))
+    depth_limit: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'broadcust_rule', text='')
+        layout.prop(self, 'depth_limit')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        if self.inputs[-1].is_linked:
+            self.inputs.new('SvStringsSocket', 'Data')
+            self.outputs.new('SvStringsSocket', 'Data')
+
+        back_inp = list(self.inputs)[::-1]
+        empty = len(list(takewhile(lambda s: not s.is_linked, back_inp)))
+        for _ in range(empty - 1):
+            self.inputs.remove(self.inputs[-1])
+            self.outputs.remove(self.outputs[-1])
+
+        for in_s, out_s in zip(self.inputs, self.outputs):
+            out_type = 'SvStringsSocket' if not in_s.is_linked\
+                else in_s.other.bl_idname
+            if out_s.bl_idname != out_type:
+                out_s.replace_socket(out_type)
+
+    def process(self):
+        arrays = [s.sv_get(deepcopy=False) for s in self.inputs if s.is_linked]
+        if not arrays:
+            return
+        depth_limit = self.depth_limit if self.depth_limit else None
+        arrays = ak.broadcast_arrays(
+            *arrays,
+            depth_limit=depth_limit,
+            broadcast_parameters_rule=self.broadcust_rule)
+
+        arr_index = 0
+        for in_s, out_s in zip(self.inputs, self.outputs):
+            if in_s.is_linked:
+                out_s.sv_set(arrays[arr_index])
+                arr_index += 1
+
+
+register, unregister = bpy.utils.register_classes_factory([SvBroadcastArraysNode])

--- a/nodes/array/concatenate_arrays.py
+++ b/nodes/array/concatenate_arrays.py
@@ -1,0 +1,61 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+from itertools import takewhile
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvConcatenateArraysNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvConcatenateArraysNode'
+    bl_label = 'Concatenate Arrays'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    axis: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'axis')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        if self.inputs[-1].is_linked:
+            self.inputs.new('SvStringsSocket', 'Data')
+
+        back_inp = list(self.inputs)[::-1]
+        empty = len(list(takewhile(lambda s: not s.is_linked, back_inp)))
+        for _ in range(empty - 1):
+            self.inputs.remove(self.inputs[-1])
+
+        others = {s.other.bl_idname for s in self.inputs if s.is_linked}
+        out_type = 'SvStringsSocket' if len(others) != 1 else others.pop()
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        arrays = [s.sv_get(deepcopy=False) for s in self.inputs if s.is_linked]
+        if not arrays:
+            return
+        self.outputs[0].sv_set(ak.concatenate(arrays, axis=self.axis))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvConcatenateArraysNode])

--- a/nodes/array/flatten_array.py
+++ b/nodes/array/flatten_array.py
@@ -1,0 +1,54 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty, BoolProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvFlattenArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvFlattenArrayNode'
+    bl_label = 'Flatten Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    along_axis: BoolProperty(default=True, update=lambda s, c: s.process_node(c))
+    axis: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'along_axis')
+        layout.prop(self, 'axis')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in_s = self.inputs[0]
+        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            return
+        axis = self.axis if self.along_axis else None
+        self.outputs[0].sv_set(ak.flatten(data, axis=axis))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvFlattenArrayNode])

--- a/nodes/array/flattening_array.py
+++ b/nodes/array/flattening_array.py
@@ -1,0 +1,57 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+import numpy as np
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty, BoolProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvFlatteningArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvFlatteningArrayNode'
+    bl_label = 'Flattening Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    deep: IntProperty(default=-1, update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'deep')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Counts')
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            return
+        num = self.deep if self.deep >= 0 else data.ndim+self.deep
+        counts = []
+        for _ in range(num):
+            counts.append(ak.num(data))
+            data = ak.flatten(data)
+        if counts:
+            counts = ak.concatenate([c[np.newaxis] for c in reversed(counts)])
+        else:
+            counts = ak.Array([])
+        self.outputs[0].sv_set(data)
+        self.outputs[1].sv_set(counts)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvFlatteningArrayNode])

--- a/nodes/array/flip_mesh_normals_array.py
+++ b/nodes/array/flip_mesh_normals_array.py
@@ -1,0 +1,50 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+from copy import copy
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrFlipMeshNormalsNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+     Triggers: array
+     Tooltip:
+     """
+    bl_idname = 'SvArrFlipMeshNormalsNode'
+    bl_label = 'Flip Mesh Normals (Array)'
+    sv_icon = 'SV_ALPHA'
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        self.inputs.new('SvStringsSocket', 'Mask')
+        self.outputs.new('SvStringsSocket', 'Array')
+
+    def process(self):
+        mesh = self.inputs['Array'].sv_get(deepcopy=False, default=None)
+        if mesh is None:
+            return
+        mask = self.inputs['Mask'].sv_get(deepcopy=False, default=None)
+        mesh = copy(mesh)
+        new_faces = mesh.faces[..., ::-1]
+        if mask is not None:
+            new_faces = ak.where(mask, new_faces, mesh.faces)
+        # if mask is None:
+        #     new_faces = mesh.faces[..., ::-1]
+        # else:
+        #     new_faces = ak.where(mask, ak.mask(mesh.faces, mask)[..., ::-1], mesh.faces)
+        mesh['faces'] = new_faces
+        self.outputs[0].sv_set(mesh)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrFlipMeshNormalsNode])

--- a/nodes/array/input_array.py
+++ b/nodes/array/input_array.py
@@ -1,0 +1,100 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import EnumProperty, IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvInputArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvInputArrayNode'
+    bl_label = 'Input Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    type_modes = [
+        ("FLOAT", "Float", "", 0),
+        ("INT", "Integer", "", 1),
+        ("VECTOR", "Vector", "", 2),
+    ]
+
+    sock_types = {'FLOAT': 'SvStringsSocket',
+                  'INT': 'SvStringsSocket',
+                  'VECTOR': 'SvVerticesSocket'}
+
+    def mode_change(self, context):
+        mode = self.type_mode
+        for sock in self.inputs:
+            if sock.bl_idname != self.sock_types[mode]:
+                sock = sock.replace_socket(self.sock_types[mode])
+            self.set_socket_prop(sock)
+        if self.outputs[0].bl_idname != self.sock_types[mode]:
+            self.outputs[0].replace_socket(self.sock_types[mode])
+        self.process_node(context)
+
+    type_mode: EnumProperty(
+        name='Number Type',
+        items=type_modes,
+        update=mode_change)
+
+    def size_change(self, context):
+        mode = self.type_mode
+        diff = self.size - len(self.inputs)
+        for _ in range(diff):
+            sock = self.inputs.new(self.sock_types[mode], 'Data')
+            self.set_socket_prop(sock)
+        for _ in range(-diff):
+            self.inputs.remove(self.inputs[-1])
+        self.process_node(context)
+
+    def set_socket_prop(self, socket):
+        mode = self.type_mode
+        socket.use_prop = True
+        if mode == 'INT':
+            socket.default_property_type = 'int'
+        elif mode == 'FLOAT':
+            socket.default_property_type = 'float'
+        elif mode == 'VECTOR':
+            socket.expanded = True
+
+    size: IntProperty(default=1, min=0, soft_max=10, max=1000, update=size_change)
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, "type_mode", text="")
+        layout.prop(self, "size")
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', "Data").use_prop = True
+        self.outputs.new('SvStringsSocket', "Data")
+
+    def process(self):
+        data = []
+        for sock in self.inputs:
+            if sock.is_linked:
+                data.append([sock.sv_get(deepcopy=False)])
+            else:
+                val = sock.sv_get(deepcopy=False)
+                if self.type_mode == 'VECTOR':
+                    data.append([list(val[0][0])])
+                else:
+                    data.append(val[0])
+
+        out = ak.concatenate(data) if data else ak.Array([])
+        self.outputs[0].sv_set(out)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvInputArrayNode])

--- a/nodes/array/input_array.py
+++ b/nodes/array/input_array.py
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: GPL3
 # License-Filename: LICENSE
+import numpy as np
 
 try:
     import awkward as ak
@@ -89,7 +90,7 @@ class SvInputArrayNode(SverchCustomTreeNode, bpy.types.Node):
             else:
                 val = sock.sv_get(deepcopy=False)
                 if self.type_mode == 'VECTOR':
-                    data.append([list(val[0][0])])
+                    data.append(ak.Array(list(val[0][0]))[np.newaxis])
                 else:
                     data.append(val[0])
 

--- a/nodes/array/input_value.py
+++ b/nodes/array/input_value.py
@@ -64,6 +64,7 @@ class SvInputValueNode(SverchCustomTreeNode, bpy.types.Node):
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', "Data").use_prop = True
         self.outputs.new('SvStringsSocket', "Data")
+        self.width = 100
 
     def process(self):
         sock = self.inputs[0]
@@ -79,7 +80,7 @@ class SvInputValueNode(SverchCustomTreeNode, bpy.types.Node):
         else:
             val = sock.sv_get(deepcopy=False)
             if self.type_mode == 'VECTOR':
-                value = ak.Array([list(val[0][0])])
+                value = ak.Array(list(val[0][0]))
             else:
                 value = val[0][0]
 

--- a/nodes/array/input_value.py
+++ b/nodes/array/input_value.py
@@ -1,0 +1,89 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import EnumProperty, IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvInputValueNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvInputValueNode'
+    bl_label = 'Input Value'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    type_modes = [
+        ("FLOAT", "Float", "", 0),
+        ("INT", "Integer", "", 1),
+        ("VECTOR", "Vector", "", 2),
+    ]
+
+    sock_types = {'FLOAT': 'SvStringsSocket',
+                  'INT': 'SvStringsSocket',
+                  'VECTOR': 'SvVerticesSocket'}
+
+    def mode_change(self, context):
+        mode = self.type_mode
+        sock = self.inputs[0]
+        if sock.bl_idname != self.sock_types[mode]:
+            sock = sock.replace_socket(self.sock_types[mode])
+        mode = self.type_mode
+        sock.use_prop = True
+        if mode == 'INT':
+            sock.default_property_type = 'int'
+        elif mode == 'FLOAT':
+            sock.default_property_type = 'float'
+        elif mode == 'VECTOR':
+            sock.expanded = True
+        if self.outputs[0].bl_idname != self.sock_types[mode]:
+            self.outputs[0].replace_socket(self.sock_types[mode])
+        self.process_node(context)
+
+    type_mode: EnumProperty(
+        name='Number Type',
+        items=type_modes,
+        update=mode_change)
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, "type_mode", text="")
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', "Data").use_prop = True
+        self.outputs.new('SvStringsSocket', "Data")
+
+    def process(self):
+        sock = self.inputs[0]
+        if sock.is_linked:
+            data = sock.sv_get(deepcopy=False)
+            for _ in range(100):
+                if isinstance(data, (float, int)):
+                    value = data
+                    break
+                data = data[0]
+            else:
+                raise RuntimeError("Was not able to extract value from the input data")
+        else:
+            val = sock.sv_get(deepcopy=False)
+            if self.type_mode == 'VECTOR':
+                value = ak.Array([list(val[0][0])])
+            else:
+                value = val[0][0]
+
+        self.outputs[0].sv_set(value)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvInputValueNode])

--- a/nodes/array/join_mesh_array.py
+++ b/nodes/array/join_mesh_array.py
@@ -1,0 +1,52 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+from copy import copy
+import numpy as np
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrJoinMeshNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+     Triggers: array
+     Tooltip:
+     """
+    bl_idname = 'SvArrJoinMeshNode'
+    bl_label = 'Join Mesh (Array)'
+    sv_icon = 'SV_MOVE'
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        self.outputs.new('SvStringsSocket', 'Array')
+
+    def process(self):
+        mesh = self.inputs['Array'].sv_get(deepcopy=False, default=None)
+        if mesh is None:
+            return
+
+        verts_num = ak.num(mesh.verts)  # [2, 1, 3, 2]
+        cum_num = np.cumsum(verts_num)  # [2, 3, 6, 8]
+        previous_num = cum_num - verts_num  # [0, 2, 3, 6]
+        verts = ak.flatten(mesh.verts, axis=1)[np.newaxis]
+        out_mesh = {'verts': verts}
+        if 'edges' in mesh.fields:
+            edges = mesh.edges + previous_num
+            out_mesh['edges'] = ak.flatten(edges, axis=1)[np.newaxis]
+        if 'faces' in mesh.fields:
+            faces = mesh.faces + previous_num
+            out_mesh['faces'] = ak.flatten(faces, axis=1)[np.newaxis]
+        self.outputs[0].sv_set(ak.Array(out_mesh))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrJoinMeshNode])

--- a/nodes/array/join_mesh_array.py
+++ b/nodes/array/join_mesh_array.py
@@ -24,7 +24,7 @@ class SvArrJoinMeshNode(SverchCustomTreeNode, bpy.types.Node):
      """
     bl_idname = 'SvArrJoinMeshNode'
     bl_label = 'Join Mesh (Array)'
-    sv_icon = 'SV_MOVE'
+    sv_icon = 'SV_ALPHA'
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', 'Array')

--- a/nodes/array/local_index.py
+++ b/nodes/array/local_index.py
@@ -9,7 +9,6 @@ import bpy
 from bpy.props import IntProperty
 
 from sverchok.node_tree import SverchCustomTreeNode
-from sverchok_extra.utils import array_math as amath
 
 try:
     import awkward as ak
@@ -17,42 +16,31 @@ except ImportError:
     ak = None
 
 
-class SvArrGetItemNode(SverchCustomTreeNode, bpy.types.Node):
+class SvLocalIndexNode(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: array
     Tooltip:
     """
-    bl_idname = 'SvArrGetItemNode'
-    bl_label = 'Get Item (Array)'
+    bl_idname = 'SvLocalIndexNode'
+    bl_label = 'Local Index'
     sv_icon = 'SV_ALPHA'
     sv_dependencies = ['awkward']
 
-    axis: IntProperty(update=lambda s, c: s.process_node(c))
+    axis: IntProperty(default=-1, update=lambda s, c: s.process_node(c))
 
     def sv_draw_buttons(self, context, layout):
         layout.prop(self, 'axis')
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', 'Data')
-        s = self.inputs.new('SvStringsSocket', 'Index')
-        s.use_prop = True
-        s.default_property_type = 'int'
         self.outputs.new('SvStringsSocket', 'Data')
-
-    def sv_update(self):
-        in_s = self.inputs[0]
-        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
-        if self.outputs[0].bl_idname != out_type:
-            self.outputs[0].replace_socket(out_type)
 
     def process(self):
         data = self.inputs[0].sv_get(deepcopy=False, default=None)
         if data is None:
             return
-        where = self.inputs[1].sv_get(deepcopy=False)
-        where = where if self.inputs[1].is_linked else where[0][0]
-        data = data[amath.slices(where, axis=self.axis)]
-        self.outputs[0].sv_set(data)
+        indexes = ak.local_index(data, axis=self.axis)
+        self.outputs[0].sv_set(indexes)
 
 
-register, unregister = bpy.utils.register_classes_factory([SvArrGetItemNode])
+register, unregister = bpy.utils.register_classes_factory([SvLocalIndexNode])

--- a/nodes/array/matrix_transform.py
+++ b/nodes/array/matrix_transform.py
@@ -1,0 +1,49 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+from copy import copy
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok_extra.utils import array_math as amath
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvArrMatrixTransformNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrMatrixTransformNode'
+    bl_label = 'Apply Matrix (Array)'
+    sv_icon = 'SV_ALPHA'
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', "Array")
+        self.inputs.new('SvMatrixSocket', "Matrices")
+
+        self.outputs.new('SvStringsSocket', "Array")
+
+    def process(self):
+        mesh = self.inputs[0].sv_get(default=None, deepcopy=False)
+        matrices = self.inputs[1].sv_get(default=None, deepcopy=False)
+        if mesh is None or matrices is None:
+            if mesh is not None:
+                self.outputs[0].sv_set(mesh)
+            return
+
+        verts = amath.apply_matrix_4x4(mesh.verts, matrices)
+        me = copy(mesh)
+        me['verts'] = verts
+        self.outputs[0].sv_set(me)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrMatrixTransformNode])

--- a/nodes/array/move_mesh_array.py
+++ b/nodes/array/move_mesh_array.py
@@ -25,7 +25,7 @@ class SvArrMoveMeshNode(SverchCustomTreeNode, bpy.types.Node):
     bl_idname = 'SvArrMoveMeshNode'
     bl_label = 'Move Mesh (Array)'
     bl_icon = 'ORIENTATION_VIEW'
-    sv_icon = 'SV_MOVE'
+    sv_icon = 'SV_ALPHA'
 
     def sv_init(self, context):
         self.inputs.new('SvStringsSocket', 'Array')

--- a/nodes/array/move_mesh_array.py
+++ b/nodes/array/move_mesh_array.py
@@ -1,0 +1,54 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+from copy import copy
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrMoveMeshNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: Moves Vertices array
+    Tooltip: Moves vectors based in another vector set and a multipier factor
+    """
+    bl_idname = 'SvArrMoveMeshNode'
+    bl_label = 'Move Mesh (Array)'
+    bl_icon = 'ORIENTATION_VIEW'
+    sv_icon = 'SV_MOVE'
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Array')
+        self.inputs.new('SvVerticesSocket', 'Movement Vectors').use_prop = True
+        s = self.inputs.new('SvStringsSocket', 'Factor')
+        s.use_prop = True
+        s.default_float_property = 1.0
+        self.outputs.new('SvStringsSocket', 'Array')
+
+    def process(self):
+        mesh = self.inputs['Array'].sv_get(deepcopy=False, default=None)
+        if mesh is None:
+            return
+        mesh = copy(mesh)
+        move = self.inputs['Movement Vectors'].sv_get(deepcopy=False)
+        if not self.inputs['Movement Vectors'].is_linked:
+            move = ak.Array(move[0][0])[np.newaxis, np.newaxis]  # https://github.com/scikit-hep/awkward/discussions/2118
+        factor = self.inputs['Factor'].sv_get(deepcopy=False)
+        if not self.inputs['Factor'].is_linked:
+            factor = factor[0][0]
+
+        mesh['verts'] = mesh.verts + move * factor
+        self.outputs[0].sv_set(mesh)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrMoveMeshNode])

--- a/nodes/array/move_vertices.py
+++ b/nodes/array/move_vertices.py
@@ -1,0 +1,52 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvArrMoveVerticesNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: Moves Vertices array
+    Tooltip: Moves vectors based in another vector set and a multipier factor
+    """
+    bl_idname = 'SvArrMoveVerticesNode'
+    bl_label = 'Move Vertices (Array)'
+    bl_icon = 'ORIENTATION_VIEW'
+    sv_icon = 'SV_MOVE'
+
+    def sv_init(self, context):
+        self.inputs.new('SvVerticesSocket', 'Vertices')
+        self.inputs.new('SvVerticesSocket', 'Movement Vectors').use_prop = True
+        s = self.inputs.new('SvStringsSocket', 'Factor')
+        s.use_prop = True
+        s.default_float_property = 1.0
+        self.outputs.new('SvVerticesSocket', 'Vertices')
+
+    def process(self):
+        verts = self.inputs['Vertices'].sv_get(deepcopy=False, default=None)
+        if verts is None:
+            self.outputs[0].sv_set([])
+            return
+        move = self.inputs['Movement Vectors'].sv_get(deepcopy=False)
+        if not self.inputs['Movement Vectors'].is_linked:
+            move = ak.Array(move[0][0])[np.newaxis, np.newaxis]  # https://github.com/scikit-hep/awkward/discussions/2118
+        factor = self.inputs['Factor'].sv_get(deepcopy=False)
+        if not self.inputs['Factor'].is_linked:
+            factor = factor[0][0]
+        result = verts + move * factor
+        self.outputs[0].sv_set(result)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrMoveVerticesNode])

--- a/nodes/array/move_vertices.py
+++ b/nodes/array/move_vertices.py
@@ -24,7 +24,7 @@ class SvArrMoveVerticesNode(SverchCustomTreeNode, bpy.types.Node):
     bl_idname = 'SvArrMoveVerticesNode'
     bl_label = 'Move Vertices (Array)'
     bl_icon = 'ORIENTATION_VIEW'
-    sv_icon = 'SV_MOVE'
+    sv_icon = 'SV_ALPHA'
 
     def sv_init(self, context):
         self.inputs.new('SvVerticesSocket', 'Vertices')

--- a/nodes/array/print_array.py
+++ b/nodes/array/print_array.py
@@ -1,0 +1,82 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import EnumProperty, StringProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok.ui import bgl_callback_nodeview as sv_bgl
+
+
+class SvPrintArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvPrintArrayNode'
+    bl_label = 'Inspect Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    modes = [
+        ('PRINT', 'Print', '', 0),
+        ('TYPE', 'Type', '', 1),
+        ('DIMENSIONS', 'Dimensions', '', 2),
+        ('FIELDS', 'Fields', '', 3),
+        ('LAYOUT', 'Layout', '', 4),
+    ]
+
+    mode: EnumProperty(items=modes, update=lambda s, c: s.process_node(c))
+    field: StringProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'mode', text='')
+        col = layout.column()
+        if not self.get('valid', True):
+            col.alert = True
+        col.prop(self, 'field')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+
+    def sv_free(self):
+        sv_bgl.callback_disable(self.node_id)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            sv_bgl.callback_disable(self.node_id)
+            return
+        if not hasattr(data, '__len__'):  # probably a number
+            sv_bgl.draw_text(self, str(data))
+            return
+        field = self.field if self.field in data.fields else None
+        self['valid'] = not (field is None and self.field)
+        if field:
+            data = data[field]
+        if self.mode == 'PRINT':
+            # text = repr(data)
+            text = data.show(type=True, stream=None)
+        elif self.mode == 'TYPE':
+            text = data.typestr
+        elif self.mode == 'DIMENSIONS':
+            text = str(data.ndim)
+        elif self.mode == 'FIELDS':
+            text = str(data.fields)
+        elif self.mode == 'LAYOUT':
+            text = str(data.layout)
+        else:
+            raise TypeError(f"Unknown {self.mode=}")
+        sv_bgl.draw_text(self, text)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvPrintArrayNode])

--- a/nodes/array/py_to_array.py
+++ b/nodes/array/py_to_array.py
@@ -1,0 +1,44 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvPyToArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvPyToArrayNode'
+    bl_label = 'Python to Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in_s = self.inputs[0]
+        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=[])
+        self.outputs[0].sv_set(ak.Array(data))
+
+
+register, unregister = bpy.utils.register_classes_factory([SvPyToArrayNode])

--- a/nodes/array/random_array.py
+++ b/nodes/array/random_array.py
@@ -1,0 +1,141 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import EnumProperty, IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvRandomArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvRandomArrayNode'
+    bl_label = 'Random array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    type_modes = [
+        ("FLOAT", "Float", "", 0),
+        ("INT", "Integer", "", 1),
+        ("VECTOR", "Vector", "", 2),
+    ]
+
+    def mode_change(self, context):
+        mode = self.type_mode
+        sock_type = mode.lower() if mode in {'FLOAT', 'INT'} else 'float'
+        self.inputs['Min'].default_property_type = sock_type
+        self.inputs['Max'].default_property_type = sock_type
+
+        self.inputs['Min'].enabled = mode in {'FLOAT', 'INT'}
+        self.inputs['Max'].enabled = mode in {'FLOAT', 'INT'}
+        self.inputs['Vector Min'].enabled = mode == 'VECTOR'
+        self.inputs['Vector Max'].enabled = mode == 'VECTOR'
+        out_type = 'SvVerticesSocket' if mode == 'VECTOR' else 'SvStringsSocket'
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+        self.process_node(context)
+
+    type_mode: EnumProperty(
+        name='Number Type',
+        items=type_modes,
+        update=mode_change)
+    seed: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_init(self, context):
+        s = self.inputs.new('SvStringsSocket', "Size")
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.default_int_property = 1
+        self.inputs.new('SvStringsSocket', "Min").use_prop = True
+        s = self.inputs.new('SvStringsSocket', "Max")
+        s.use_prop = True
+        s.default_float_property = 1
+        s.default_int_property = 1
+        s = self.inputs.new('SvVerticesSocket', "Vector Min")
+        s.use_prop = True
+        s.enabled = False
+        s = self.inputs.new('SvVerticesSocket', "Vector Max")
+        s.use_prop = True
+        s.default_property = 1, 1, 1
+        s.enabled = False
+
+        self.outputs.new('SvStringsSocket', "Data")
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, "type_mode", text="")
+        layout.prop(self, "seed")
+
+    def process(self):
+        sizes = self.inputs['Size'].sv_get(deepcopy=False)
+        sizes = sizes if self.inputs['Size'].is_linked else sizes[0][0]
+        min_val = self.inputs['Min'].sv_get(deepcopy=False)
+        if not self.inputs['Min'].is_linked:
+            min_val = min_val[0][0]
+        max_val = self.inputs['Max'].sv_get(deepcopy=False)
+        if not self.inputs['Max'].is_linked:
+            max_val = max_val[0][0]
+        min_vec = self.inputs['Vector Min'].sv_get(deepcopy=False)
+        if not self.inputs['Vector Min'].is_linked:
+            min_vec = ak.Array(min_vec[0][0])
+        max_vec = self.inputs['Vector Max'].sv_get(deepcopy=False)
+        if not self.inputs['Vector Max'].is_linked:
+            max_vec = ak.Array(max_vec[0][0])
+
+        rng = np.random.default_rng(self.seed)
+        if self.type_mode in {'FLOAT', 'INT'}:
+            data = [sizes, min_val, max_val]
+            if any(not isinstance(v, (float, int)) for v in data):
+                sizes, min_val, max_val = ak.broadcast_arrays(*data)
+                size = ak.sum(ak.flatten(sizes, axis=None))
+                out = rng.random(size)
+                out = ak.unflatten(out, sizes)
+            else:
+                out = rng.random(sizes)
+            if self.type_mode == 'FLOAT':
+                range_ = max_val - min_val
+                out = out * range_ + min_val
+            else:
+                range_ = max_val - min_val + 1
+                out = out * range_ + min_val
+                out = ak.values_astype(out, int)
+
+        elif self.type_mode == 'VECTOR':
+            if not all(isinstance(v, (float, int))
+                       or isinstance(v[0], (float, int))
+                       for v in [sizes, min_vec, max_vec]):
+                min_vec = min_vec[np.newaxis] \
+                    if isinstance(min_vec[0], (float, tuple)) else min_vec
+                max_vec = max_vec[np.newaxis] \
+                    if isinstance(max_vec[0], (float, tuple)) else max_vec
+                sizes, min_vec, max_vec = ak.broadcast_arrays(
+                    sizes, min_vec, max_vec, depth_limit=1, right_broadcast=False)
+                size = ak.sum(ak.flatten(sizes, axis=None))
+                out = rng.random((size, 3), dtype=np.float32)
+                out = ak.unflatten(out, sizes)
+                range_ = max_vec - min_vec
+                out = out * range_[:,np.newaxis] + min_vec[:,np.newaxis]
+            else:
+                out = rng.random((sizes, 3), dtype=np.float32)
+                range_ = max_vec - min_vec
+                out = out * range_ + min_vec
+        else:
+            raise(TypeError(f"Unknown type {self.type_mode=}"))
+
+        out = ak.Array(out)
+        self.outputs[0].sv_set(out)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvRandomArrayNode])

--- a/nodes/array/run_lengths.py
+++ b/nodes/array/run_lengths.py
@@ -1,0 +1,40 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvArrRunLengthsNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvArrRunLengthsNode'
+    bl_label = 'Run Lengths (Array)'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Lengths')
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            return
+        lens = ak.run_lengths(data)
+        self.outputs[0].sv_set(lens)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvArrRunLengthsNode])

--- a/nodes/array/slice_array.py
+++ b/nodes/array/slice_array.py
@@ -1,0 +1,108 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import bpy
+from bpy.props import IntProperty, EnumProperty
+from sverchok.data_structure import fixed_iter
+
+from sverchok.node_tree import SverchCustomTreeNode
+from sverchok_extra.utils import array_math as amath
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+class SvSliceArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvSliceArrayNode'
+    bl_label = 'Slice Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    slice_types = [
+        ('START', 'Start', ''),
+        ('STOP', 'Stop', ''),
+        ('STEP', 'Step', ''),
+    ]
+
+    def update_slice_type(self, context):
+        self.inputs['Start'].enabled = 'START' in self.slice_type
+        self.inputs['Stop'].enabled = 'STOP' in self.slice_type
+        self.inputs['Step'].enabled = 'STEP' in self.slice_type
+        self.process_node(context)
+
+    slice_type: EnumProperty(
+        items=slice_types,
+        default={'STOP'},
+        options={'ENUM_FLAG'},
+        update=update_slice_type)
+    axis: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'slice_type', expand=True, text=None)
+        layout.prop(self, 'axis')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        s = self.inputs.new('SvStringsSocket', 'Start')
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.enabled = False
+        s = self.inputs.new('SvStringsSocket', 'Stop')
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.default_int_property = 1
+        s = self.inputs.new('SvStringsSocket', 'Step')
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.default_int_property = 1
+        s.enabled = False
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in_s = self.inputs[0]
+        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            return
+        s1, s2, s3 = self.inputs['Start'], self.inputs['Stop'], self.inputs['Step']
+        start = s1.sv_get(deepcopy=False)
+        start = start if s1.is_linked else start[0][0]
+        start = start if s1.enabled else None
+        stop = s2.sv_get(deepcopy=False)
+        stop = stop if s2.is_linked else stop[0][0]
+        stop = stop if s2.enabled else None
+        step = s3.sv_get(deepcopy=False)
+        step = step if s3.is_linked else step[0][0]
+        step = step if s3.enabled else None
+
+        if any(s.enabled and s.is_linked for s in self.inputs[1:]):
+            start = start if s1.is_linked and s1.enabled else [start]
+            stop = stop if s2.is_linked and s2.enabled else [stop]
+            step = step if s3.is_linked and s3.enabled else [step]
+            num = max(len(v) for v in [start, stop, step])
+            sss = [fixed_iter(start, num), fixed_iter(stop, num), fixed_iter(step, num)]
+            sl = []
+            for sa, so, se in zip(*sss):
+                sl.append(slice(sa, so, se))
+            sl = tuple(sl)
+        else:
+            sl = amath.slices(slice(start, stop, step), axis=self.axis)
+        data = data[sl]
+        self.outputs[0].sv_set(data)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvSliceArrayNode])

--- a/nodes/array/to_regular_array.py
+++ b/nodes/array/to_regular_array.py
@@ -1,0 +1,54 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+import numpy as np
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvToRegularArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvToRegularArrayNode'
+    bl_label = 'To Regular Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    axis: IntProperty(default=1, update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'axis')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in_s = self.inputs[0]
+        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            data = ak.Array([])
+        else:
+            data = ak.to_regular(data, axis=self.axis)
+        self.outputs[0].sv_set(data)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvToRegularArrayNode])

--- a/nodes/array/unflatten_array.py
+++ b/nodes/array/unflatten_array.py
@@ -1,0 +1,62 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvUnflattenArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvUnflattenArrayNode'
+    bl_label = 'Unflatten Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    axis: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'axis')
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        s = self.inputs.new('SvStringsSocket', 'Counts')
+        s.use_prop = True
+        s.default_property_type = 'int'
+        s.default_int_property = 1
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in_s = self.inputs[0]
+        out_type = 'SvStringsSocket' if not in_s.is_linked else in_s.other.bl_idname
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            self.outputs[0].sv_set(ak.Array([]))
+            return
+        counts = self.inputs[1].sv_get(deepcopy=False)
+        if not self.inputs[1].is_linked:
+            counts = counts[0][0]
+        # if len(counts) == 1 and isinstance(counts[0], (int, float)):
+        #     counts = counts[0]
+        data = ak.unflatten(data, counts, axis=self.axis)
+        self.outputs[0].sv_set(data)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvUnflattenArrayNode])

--- a/nodes/array/unflattening_array.py
+++ b/nodes/array/unflattening_array.py
@@ -1,0 +1,48 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvUnflatteningArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvUnflatteningArrayNode'
+    bl_label = 'Unflattening Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+        self.inputs.new('SvStringsSocket', 'Counts')
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        counts = self.inputs[1].sv_get(deepcopy=False, default=None)
+        if counts is None:
+            if data is not None:
+                self.outputs[0].sv_set(data)
+            return
+        if data is None:
+            return
+        for count in counts:
+            data = ak.unflatten(data, count)
+        self.outputs[0].sv_set(data)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvUnflatteningArrayNode])

--- a/nodes/array/unzip_array.py
+++ b/nodes/array/unzip_array.py
@@ -1,0 +1,55 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvUnzipArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvUnzipArrayNode'
+    bl_label = 'Unzip Arrays'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None or not hasattr(data, 'fields'):
+            self.outputs.clear()
+            return
+
+        diff = len(data.fields) - len(self.outputs)
+        for _ in range(diff):
+            self.outputs.new('SvStringsSocket', '')
+        for _ in range(-diff):
+            self.outputs.remove(self.outputs[-1])
+
+        for name, sock in zip(data.fields, self.outputs):
+            sock.name = name
+
+    def process(self):
+        data = self.inputs[0].sv_get(deepcopy=False, default=None)
+        if data is None:
+            return
+        out = ak.unzip(data)
+        for out_data, sock in zip(out, self.outputs):
+            sock.sv_set(out_data)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvUnzipArrayNode])

--- a/nodes/array/where_array.py
+++ b/nodes/array/where_array.py
@@ -1,0 +1,56 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvWhereArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvWhereArrayNode'
+    bl_label = 'Where Array'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    def sv_init(self, context):
+        self.inputs.new('SvStringsSocket', 'Condition')
+        self.inputs.new('SvStringsSocket', 'False')
+        self.inputs.new('SvStringsSocket', 'True')
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        in1 = self.inputs[0]
+        type1 = 'SvStringsSocket' if not in1.is_linked else in1.other.bl_idname
+        in2 = self.inputs[1]
+        type2 = 'SvStringsSocket' if not in2.is_linked else in2.other.bl_idname
+        out_type = type1 if type1 == type2 else 'SvStringsSocket'
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def process(self):
+        condition = self.inputs['Condition'].sv_get(deepcopy=False, default=None)
+        if condition is None:
+            return
+        false = self.inputs['False'].sv_get(deepcopy=False, default=None)
+        true = self.inputs['True'].sv_get(deepcopy=False, default=None)
+        if false is not None or true is not None:
+            result = ak.where(condition, true, false)
+        else:
+            result = ak.where(condition)
+        self.outputs[0].sv_set(result)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvWhereArrayNode])

--- a/nodes/array/zip_array.py
+++ b/nodes/array/zip_array.py
@@ -1,0 +1,71 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+
+from itertools import takewhile
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+import bpy
+from bpy.props import IntProperty
+
+from sverchok.node_tree import SverchCustomTreeNode
+
+
+class SvZipArrayNode(SverchCustomTreeNode, bpy.types.Node):
+    """
+    Triggers: array
+    Tooltip:
+    """
+    bl_idname = 'SvZipArrayNode'
+    bl_label = 'Zip Arrays'
+    sv_icon = 'SV_ALPHA'
+    sv_dependencies = ['awkward']
+
+    depth_limit: IntProperty(update=lambda s, c: s.process_node(c))
+
+    def sv_draw_buttons(self, context, layout):
+        layout.prop(self, 'depth_limit')
+
+    def sv_init(self, context):
+        self.inputs.new('SvTextSocket', 'Data').custom_draw = 'draw_field'
+        self.outputs.new('SvStringsSocket', 'Data')
+
+    def sv_update(self):
+        if self.inputs[-1].is_linked:
+            self.inputs.new('SvTextSocket', 'Data').custom_draw = 'draw_field'
+
+        back_inp = list(self.inputs)[::-1]
+        empty = len(list(takewhile(lambda s: not s.is_linked, back_inp)))
+        for _ in range(empty - 1):
+            self.inputs.remove(self.inputs[-1])
+
+        others = {s.other.bl_idname for s in self.inputs if s.is_linked}
+        out_type = 'SvStringsSocket' if len(others) != 1 else others.pop()
+        if self.outputs[0].bl_idname != out_type:
+            self.outputs[0].replace_socket(out_type)
+
+    def draw_field(self, socket, context, layout):
+        layout.prop(socket, 'default_property', text='')
+
+    def process(self):
+        arrays = [s.sv_get(deepcopy=False) for s in self.inputs if s.is_linked]
+        if not arrays:
+            return
+        fields = [s.default_property for s in self.inputs if s.is_linked]
+        depth_limit = self.depth_limit if self.depth_limit else None
+        if any(fields):
+            out = ak.zip({n: d for n, d in zip(fields, arrays)},
+                         depth_limit=depth_limit)
+        else:
+            out = ak.zip(arrays, depth_limit=depth_limit)
+        self.outputs[0].sv_set(out)
+
+
+register, unregister = bpy.utils.register_classes_factory([SvZipArrayNode])

--- a/utils/array_math/__init__.py
+++ b/utils/array_math/__init__.py
@@ -1,0 +1,136 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+import numpy as np
+
+try:
+    import awkward as ak
+except ImportError:
+    ak = None
+
+
+def vert_length(verts):
+    return ak.sum(verts ** 2, axis=-1) ** 0.5
+
+
+def scale_vert(verts, scale):
+    """
+    >> v=scale_vert(ak.Array([[[1,1,1],[2,2,2],[3,3,3]],[[4,4,4],[5,5,5]]]), ak.Array([[10,20,0],[2,3]])).show(stream=None)
+    >> print(v)
+    [[[10, 10, 10], [40, 40, 40], [0, 0, 0]],
+     [[8, 8, 8], [15, 15, 15]]]
+    """
+    return verts * scale[..., np.newaxis]
+
+
+def repeat_array(a, repeats):
+    pass
+
+
+def segment_length(verts):
+    """Distances between first and second vertices"""
+    vert1 = verts[..., :-1, :]
+    vert2 = verts[..., 1:, :]
+    dist_vec = vert2 - vert1
+    return vert_length(dist_vec)
+
+
+def polyline_length(verts):
+    """Sum of distances between all vectors innermost lists"""
+    return ak.sum(segment_length(verts), axis=-1)
+
+
+def subdivide_polyline(verts, cuts, interpolation='LINEAR'):
+    """Only works with list of polylines"""
+    lines_mum = len(verts)
+    segment_num = ak.num(verts, axis=-2) - 1
+    segment_shape = ak.num(verts, axis=-1)[..., :-1]
+    _, count_per_seg = ak.broadcast_arrays(segment_shape, cuts)
+    new_verts_num = segment_num * cuts + ak.num(verts)
+    total_num = ak.sum(new_verts_num)
+    seg_weight = np.zeros(total_num - lines_mum)
+    seg_weight = ak.unflatten(seg_weight, ak.flatten(count_per_seg)+1)
+    seg_weight = ak.unflatten(seg_weight, segment_num)
+    seg_weight = ak.local_index(seg_weight)
+    seg_weight = seg_weight / (count_per_seg+1)
+    if interpolation == 'LINEAR':
+        vert1 = verts[..., :-1, :]
+        vert1, _ = ak.unzip(ak.cartesian([vert1[..., np.newaxis, :], seg_weight], axis=2))
+        vert2 = verts[..., 1:, :]
+        vert2, _ = ak.unzip(ak.cartesian([vert2[..., np.newaxis, :], seg_weight], axis=2))
+        new_verts = linear_interpolation(vert1, vert2, seg_weight)
+    elif interpolation in {'CUBIC', 'CATMULL_ROM'}:
+        verts = extend_polyline(verts)
+        v0 = verts[..., :-3, :]
+        v0, _ = ak.unzip(ak.cartesian([v0[..., np.newaxis, :], seg_weight], axis=2))
+        v1 = verts[..., 1:-2, :]
+        v1, _ = ak.unzip(ak.cartesian([v1[..., np.newaxis, :], seg_weight], axis=2))
+        v2 = verts[..., 2:-1, :]
+        v2, _ = ak.unzip(ak.cartesian([v2[..., np.newaxis, :], seg_weight], axis=2))
+        v3 = verts[..., 3:, :]
+        v3, _ = ak.unzip(ak.cartesian([v3[..., np.newaxis, :], seg_weight], axis=2))
+        if interpolation == 'CUBIC':
+            new_verts = cubic_interpolation(v0, v1, v2, v3, seg_weight)
+        else:
+            new_verts = catmull_rom_interpolation(v0, v1, v2, v3, seg_weight)
+    else:
+        raise TypeError(f"{interpolation=} is not among supported.")
+    new_verts = ak.flatten(new_verts, axis=-2)
+    return new_verts
+
+
+def extend_polyline(verts):
+    """Except list of polylines which are lists of vertices. Add extra points
+    ot the start and end of them repeating previous edge slope."""
+    v1 = verts[..., 0, :]
+    v2 = verts[..., 1, :]
+    v0 = v1 + v1 - v2
+    last = verts[..., -1, :]
+    prev = verts[..., -2, :]
+    new_last = last + last - prev
+    new_verts = ak.concatenate([v0[:,np.newaxis], verts, new_last[:,np.newaxis]], axis=1)
+    return new_verts
+
+
+# http://www.paulbourke.net/miscellaneous/interpolation/
+def linear_interpolation(v1, v2, factor):
+    return scale_vert(v1, 1-factor) + scale_vert(v2, factor)
+
+
+def cubic_interpolation(v0, v1, v2, v3, factor):
+    f2 = factor**2
+    a0 = v3-v2-v0+v1
+    a1 = v0-v1-a0
+    a2 = v2-v0
+    a3 = v1
+
+    return scale_vert(a0, f2 * factor) + scale_vert(a1, f2) + scale_vert(a2, factor) + a3
+
+
+def catmull_rom_interpolation(v0, v1, v2, v3, factor):
+    A = ak.Array
+    f2 = factor**2
+    a0 = scale_vert(v0, A([-0.5])) + scale_vert(v1, A([1.5])) - scale_vert(v2, A([1.5])) + scale_vert(v3, A([0.5]))
+    a1 = v0 - scale_vert(v1, A([2.5])) + scale_vert(v2, A([2])) - scale_vert(v3, A([0.5]))
+    a2 = scale_vert(v0, A([-0.5])) + scale_vert(v2, A([0.5]))
+    a3 = v1
+
+    return scale_vert(a0, f2 * factor) + scale_vert(a1, f2) + scale_vert(a2, factor) + a3
+
+
+def cosine_interpolation(v1, v2, factor):
+    ft = factor * 3.1415927
+    f = (1 - np.cos(ft)) * 0.5
+    return scale_vert(v1, 1-f) + scale_vert(v2, f)
+
+
+if __name__ == '__main__':
+    p_line = ak.Array([[[0, 0, 0], [1.5, 0, 0], [2, 0.5, 0]],
+                       [[0, 0, 0], [0, 1.5, 0], [0, 2, 0.5], [0, 3, 0]]])
+    new_line = subdivide_polyline(p_line, ak.Array([1]))
+    # from timeit import timeit
+    # t=timeit('subdivide_polyline(p_line, ak.Array([5]))', 'from __main__ import ak, subdivide_polyline, p_line', number=1)
+    # print(t)

--- a/utils/array_math/__init__.py
+++ b/utils/array_math/__init__.py
@@ -6,10 +6,51 @@
 # License-Filename: LICENSE
 import numpy as np
 
+from .array_numba import add_numba_implementation
+
 try:
     import awkward as ak
 except ImportError:
     ak = None
+
+
+def slices(item, axis: int) -> tuple:
+    empty = slice(None, None, None)
+    items = []
+    if axis >= 0:
+        for _ in range(axis):
+            items.append(empty)
+        items.append(item)
+        items = tuple(items)
+    else:
+        for _ in range(abs(axis) - 1):
+            items.append(empty)
+        items.append(item)
+        items.append(...)
+        items.reverse()
+    return tuple(items)
+
+
+def flatten(array, deep=-1):
+    """Flattens array to the given deep. Return flattened array and a sequence
+    ot unflatten it back. It does not work with all arrays."""
+    num = deep if deep >= 0 else array.ndim + deep
+    counts = []
+    for _ in range(num):
+        counts.append(ak.num(array))
+        array = ak.flatten(array)
+    if counts:
+        counts = ak.concatenate([c[np.newaxis] for c in reversed(counts)])
+    else:
+        counts = ak.Array([])
+    return array, counts
+
+
+def unflatten(array, counts):
+    """Use together with `flatten`"""
+    for count in counts:
+        array = ak.unflatten(array, count)
+    return array
 
 
 def vert_length(verts):
@@ -24,6 +65,85 @@ def scale_vert(verts, scale):
      [[8, 8, 8], [15, 15, 15]]]
     """
     return verts * scale[..., np.newaxis]
+
+
+def apply_matrix_4x4(verts, matrices):
+    if verts.ndim == 2:
+        v1 = ak.concatenate([verts, [[1]]], axis=-1)
+        m = matrices[np.newaxis] if matrices.ndim == 2 else matrices
+    elif verts.ndim == 3:
+        v1 = ak.concatenate([verts, ak.Array([[1]])[np.newaxis]], axis=-1)
+        if matrices.ndim == 2:
+            m = matrices[np.newaxis, np.newaxis]
+        elif matrices.ndim == 3:
+            m = matrices[:, np.newaxis]
+        else:
+            m = matrices
+    else:
+        raise TypeError(f"{verts.ndim=}, only 2 or 3 is supported")
+    v2 = v1[..., np.newaxis, :]
+    v3 = m * v2
+    v4 = ak.sum(v3, axis=-1)
+    v5 = v4[..., :-1]
+    return v5
+
+
+def apply_matrix_3x3(verts, matrices):
+    if verts.ndim == 2:
+        m = matrices[np.newaxis] if matrices.ndim == 2 else matrices
+    elif verts.ndim == 3:
+        if matrices.ndim == 2:
+            m = matrices[np.newaxis, np.newaxis]
+        elif matrices.ndim == 3:
+            m = matrices[:, np.newaxis]
+        else:
+            m = matrices
+    else:
+        raise TypeError(f"{verts.ndim=}, only 2 or 3 is supported")
+    v1 = verts[..., np.newaxis, :]
+    v2 = m * v1
+    v3 = ak.sum(v2, axis=-1)
+    return v3
+
+
+def matrix(positions, scale):
+    pos, sc = ak.broadcast_arrays(positions, scale)
+    v0, v1, _ = ak.broadcast_arrays(0, 1, positions[..., 0])
+    w = ..., np.newaxis
+    i1 = ak.concatenate([sc[..., 0][w], v0[w], v0[w], pos[..., 0][w]], axis=-1)
+    i2 = ak.concatenate([v0[w], sc[..., 1][w], v0[w], pos[..., 1][w]], axis=-1)
+    i3 = ak.concatenate([v0[w], v0[w], sc[..., 2][w], pos[..., 2][w]], axis=-1)
+    i4 = ak.concatenate([v0[w], v0[w], v0[w], v1[w]], axis=-1)
+    m = ak.concatenate([i1[..., np.newaxis, :], i2[..., np.newaxis, :], i3[..., np.newaxis, :], i4[..., np.newaxis, :]], axis=-2)
+    return m
+
+
+def euler_to_matrix(euler):
+    # https://euclideanspace.com/maths/geometry/rotations/conversions/eulerToMatrix/index.htm
+    w = ..., np.newaxis
+    w1 = ..., np.newaxis, slice(None, None, None)
+    ch = np.cos(euler[..., 1])
+    sh = np.sin(euler[..., 1])
+    ca = np.cos(euler[..., 2])
+    sa = np.sin(euler[..., 2])
+    cb = np.cos(euler[..., 0])
+    sb = np.sin(euler[..., 0])
+
+    m00 = ch * ca
+    m01 = sh * sb - ch * sa * cb
+    m02 = ch * sa * sb + sh * cb
+    m10 = sa
+    m11 = ca * cb
+    m12 = -ca * sb
+    m20 = -sh * ca
+    m21 = sh * sa * cb + ch * sb
+    m22 = -sh * sa * sb + ch * cb
+
+    row1 = ak.concatenate([m00[w], m01[w], m02[w]], axis=-1)
+    row2 = ak.concatenate([m10[w], m11[w], m12[w]], axis=-1)
+    row3 = ak.concatenate([m20[w], m21[w], m22[w]], axis=-1)
+    m = ak.concatenate([row1[w1], row2[w1], row3[w1]], axis=-2)
+    return m
 
 
 def repeat_array(a, repeats):
@@ -43,35 +163,35 @@ def polyline_length(verts):
     return ak.sum(segment_length(verts), axis=-1)
 
 
+# @add_numba_implementation
 def subdivide_polyline(verts, cuts, interpolation='LINEAR'):
     """Only works with list of polylines"""
     lines_mum = len(verts)
     segment_num = ak.num(verts, axis=-2) - 1
     segment_shape = ak.num(verts, axis=-1)[..., :-1]
     _, count_per_seg = ak.broadcast_arrays(segment_shape, cuts)
-    new_verts_num = segment_num * cuts + ak.num(verts)
-    total_num = ak.sum(new_verts_num)
-    seg_weight = np.zeros(total_num - lines_mum)
-    seg_weight = ak.unflatten(seg_weight, ak.flatten(count_per_seg)+1)
-    seg_weight = ak.unflatten(seg_weight, segment_num)
-    seg_weight = ak.local_index(seg_weight)
-    seg_weight = seg_weight / (count_per_seg+1)
+    total_num = ak.sum(count_per_seg) + ak.sum(segment_num)
+    seg_weight0 = np.zeros(total_num)
+    seg_weight1 = ak.unflatten(seg_weight0, ak.flatten(count_per_seg)+1)
+    seg_weight2 = ak.unflatten(seg_weight1, segment_num)
+    seg_weight3 = ak.local_index(seg_weight2)
+    seg_weight = seg_weight3 / (count_per_seg+1)
     if interpolation == 'LINEAR':
         vert1 = verts[..., :-1, :]
-        vert1, _ = ak.unzip(ak.cartesian([vert1[..., np.newaxis, :], seg_weight], axis=2))
+        vert1 = vert1[..., np.newaxis, :]
         vert2 = verts[..., 1:, :]
-        vert2, _ = ak.unzip(ak.cartesian([vert2[..., np.newaxis, :], seg_weight], axis=2))
+        vert2 = vert2[..., np.newaxis, :]
         new_verts = linear_interpolation(vert1, vert2, seg_weight)
     elif interpolation in {'CUBIC', 'CATMULL_ROM'}:
-        verts = extend_polyline(verts)
-        v0 = verts[..., :-3, :]
-        v0, _ = ak.unzip(ak.cartesian([v0[..., np.newaxis, :], seg_weight], axis=2))
-        v1 = verts[..., 1:-2, :]
-        v1, _ = ak.unzip(ak.cartesian([v1[..., np.newaxis, :], seg_weight], axis=2))
-        v2 = verts[..., 2:-1, :]
-        v2, _ = ak.unzip(ak.cartesian([v2[..., np.newaxis, :], seg_weight], axis=2))
-        v3 = verts[..., 3:, :]
-        v3, _ = ak.unzip(ak.cartesian([v3[..., np.newaxis, :], seg_weight], axis=2))
+        extra_verts = extend_polyline(verts)
+        v0 = extra_verts[..., :-3, :]
+        v0 = v0[..., np.newaxis, :]
+        v1 = extra_verts[..., 1:-2, :]
+        v1 = v1[..., np.newaxis, :]
+        v2 = extra_verts[..., 2:-1, :]
+        v2 = v2[..., np.newaxis, :]
+        v3 = extra_verts[..., 3:, :]
+        v3 = v3[..., np.newaxis, :]
         if interpolation == 'CUBIC':
             new_verts = cubic_interpolation(v0, v1, v2, v3, seg_weight)
         else:
@@ -79,7 +199,20 @@ def subdivide_polyline(verts, cuts, interpolation='LINEAR'):
     else:
         raise TypeError(f"{interpolation=} is not among supported.")
     new_verts = ak.flatten(new_verts, axis=-2)
+    new_verts = ak.concatenate([new_verts, verts[..., -1, :][..., np.newaxis, :]], axis=-2)
     return new_verts
+
+
+@add_numba_implementation
+def connect_polyline(verts):
+    _, edge_shape = ak.broadcast_arrays(verts, 0, depth_limit=verts.ndim - 1)  # if cycle
+    if verts.ndim == edge_shape.ndim:  # if verts are regular the broadcast is different
+        edge_shape = ak.flatten(edge_shape, axis=-1)
+    edge_shape = edge_shape[..., :-1]  # if not cycle
+    edge_indexes = ak.local_index(edge_shape)
+    edge_wrap_ind = edge_indexes[..., np.newaxis]
+    edges = ak.concatenate([edge_wrap_ind, edge_wrap_ind + 1], axis=-1)
+    return edges
 
 
 def extend_polyline(verts):
@@ -97,7 +230,7 @@ def extend_polyline(verts):
 
 # http://www.paulbourke.net/miscellaneous/interpolation/
 def linear_interpolation(v1, v2, factor):
-    return scale_vert(v1, 1-factor) + scale_vert(v2, factor)
+    return v1 * (1-factor) + v2 * factor
 
 
 def cubic_interpolation(v0, v1, v2, v3, factor):
@@ -107,18 +240,17 @@ def cubic_interpolation(v0, v1, v2, v3, factor):
     a2 = v2-v0
     a3 = v1
 
-    return scale_vert(a0, f2 * factor) + scale_vert(a1, f2) + scale_vert(a2, factor) + a3
+    return a0 * f2 * factor + a1 * f2 + a2 * factor + a3
 
 
 def catmull_rom_interpolation(v0, v1, v2, v3, factor):
-    A = ak.Array
     f2 = factor**2
-    a0 = scale_vert(v0, A([-0.5])) + scale_vert(v1, A([1.5])) - scale_vert(v2, A([1.5])) + scale_vert(v3, A([0.5]))
-    a1 = v0 - scale_vert(v1, A([2.5])) + scale_vert(v2, A([2])) - scale_vert(v3, A([0.5]))
-    a2 = scale_vert(v0, A([-0.5])) + scale_vert(v2, A([0.5]))
+    a0 = v0 * -0.5 + v1 * 1.5 - v2 * 1.5 + v3 * 0.5
+    a1 = v0 - v1 * 2.5 + v2 * 2 - v3 * 0.5
+    a2 = v0 * -0.5 + v2 * 0.5
     a3 = v1
 
-    return scale_vert(a0, f2 * factor) + scale_vert(a1, f2) + scale_vert(a2, factor) + a3
+    return a0 * f2 * factor + a1 * f2 + a2 * factor + a3
 
 
 def cosine_interpolation(v1, v2, factor):

--- a/utils/array_math/array_numba.py
+++ b/utils/array_math/array_numba.py
@@ -1,0 +1,180 @@
+# This file is part of project Sverchok. It's copyrighted by the contributors
+# recorded in the version control history of the file, available from
+# its original location https://github.com/nortikin/sverchok/commit/master
+#
+# SPDX-License-Identifier: GPL3
+# License-Filename: LICENSE
+import logging
+from functools import wraps
+
+import numpy as np
+
+try:
+    import awkward as ak
+    import numba
+except ImportError:
+    ak = None
+    numba = None
+
+
+logger = logging.getLogger('sverchok')
+
+
+def add_numba_implementation(decorated_func):
+    if numba is not None:
+        implementation_name = decorated_func.__name__
+        try:
+            implementation = globals()[implementation_name]
+        except KeyError:
+            implementation = decorated_func
+            logger.error(f'Function "{implementation_name}" is not found')
+    else:
+        implementation = decorated_func
+
+    @wraps(implementation)
+    def wrap(*args, **kwargs):
+        return implementation(*args, **kwargs)
+
+    return wrap
+
+
+def subdivide_polyline(verts, cuts, interpolation='LINEAR'):
+    verts = ak.from_regular(verts)  # https://github.com/scikit-hep/awkward/discussions/2197
+    segment_shape = ak.num(verts, axis=-1)[..., :-1]
+    _, cuts2 = ak.broadcast_arrays(segment_shape, cuts)  # [[2, 3], [4]]
+    flat_result, flat_count = _subdivide_polylines(verts, cuts2)
+    return ak.unflatten(flat_result, flat_count, axis=0)
+
+
+def connect_polyline(verts):
+    flat_result, flat_count = _connect_polyline(verts)
+    if flat_count is not None:
+        return ak.unflatten(flat_result, flat_count, axis=0)
+    else:
+        return flat_result
+
+
+if numba is not None:
+
+    @numba.njit
+    def _subdivide_polylines(polylines, cuts):
+        # if interpolation == 'LINEAR':
+        #     interpolation_func = _linear_interpolation
+        # elif interpolation == 'CUBIC':
+        #     interpolation_func = _cubic_interpolation
+        # elif interpolation == 'CATMULL_ROM':
+        #     interpolation = _catmull_rom_interpolation
+        # else:
+        #     raise TypeError("Given interpolation type is unknown.")
+
+        # Pre-pass over the data to determine how large our arrays need to be
+        final_vertex_count = 0
+        for line_cuts in cuts:
+            for cut in line_cuts:
+                final_vertex_count += cut  # etra points inside segment
+                final_vertex_count += 1  # first point of each segment
+            final_vertex_count += 1  # last point of last segment
+
+        flat_result = np.empty((final_vertex_count, 3), dtype=np.float64)
+        flat_result = np.empty((10, 3), dtype=np.float64)
+        flat_count = np.zeros(len(polylines), dtype=np.int64)
+        flat_count = np.zeros(10, dtype=np.int64)
+
+        # Keep track of the vertex index in the flat result
+        l_vertex_index = 0
+
+        # For each polyline
+        for i_line, line in enumerate(polylines):
+            assert len(line) >= 2
+
+            # Add first point of the line
+            start = np.asarray(line[0])
+            flat_result[l_vertex_index] = start
+            l_vertex_index += 1
+
+            # For each segment (three vertices = two segments)
+            segments_num = len(line) - 1
+            for j_segment in range(segments_num):
+                seg_cuts = cuts[i_line][j_segment]
+                _subdivide_segment(
+                    line, j_segment, seg_cuts, flat_result[l_vertex_index:])
+                l_vertex_index += seg_cuts+1
+
+            flat_count[i_line] = len(line) + sum([n for n in cuts[i_line]])
+
+        return flat_result, flat_count
+
+
+    @numba.njit
+    def _subdivide_segment(polyline, segment_index, cuts, result):
+        start = np.asarray(polyline[segment_index])
+        stop = np.asarray(polyline[segment_index + 1])
+        for i, k_segment_vertex in enumerate(range(1, cuts + 2)):
+            # Interpolate between start and stop
+            t = k_segment_vertex / (cuts + 1)
+            result[i] = _linear_interpolation(start, stop, t)
+
+
+    @numba.njit
+    def _linear_interpolation(val1, val2, factor):
+        return val1 * (1 - factor) + val2 * factor
+
+
+    @numba.njit
+    def _cubic_interpolation(v0, v1, v2, v3, factor):
+        f2 = factor ** 2
+        a0 = v3 - v2 - v0 + v1
+        a1 = v0 - v1 - a0
+        a2 = v2 - v0
+        a3 = v1
+
+        return a0 * f2 * factor + a1 * f2 + a2 * factor + a3
+
+
+    @numba.njit
+    def _catmull_rom_interpolation(v0, v1, v2, v3, factor):
+        f2 = factor ** 2
+        a0 = v0 * -0.5 + v1 * 1.5 - v2 * 1.5 + v3 * 0.5
+        a1 = v0 - v1 * 2.5 + v2 * 2 - v3 * 0.5
+        a2 = v0 * -0.5 + v2 * 0.5
+        a3 = v1
+
+        return a0 * f2 * factor + a1 * f2 + a2 * factor + a3
+
+
+    @numba.njit
+    def _extend_polylines(polylines):
+        """Except list of polylines which are lists of vertices. Add extra points
+        ot the start and end of them repeating previous edge slope."""
+        v1 = verts[..., 0, :]
+        v2 = verts[..., 1, :]
+        v0 = v1 + v1 - v2
+        last = verts[..., -1, :]
+        prev = verts[..., -2, :]
+        new_last = last + last - prev
+        new_verts = ak.concatenate([v0[:, np.newaxis], verts, new_last[:, np.newaxis]], axis=1)
+        return new_verts
+
+
+    @numba.njit
+    def _connect_polyline(verts):
+        if verts.ndim == 2:
+            edges = np.zeros((len(verts)-1, 2), dtype=np.int64)
+            for i in range(len(edges)):
+                edges[i] = [i, i+1]
+            return edges, None
+        elif verts.ndim == 3:
+            verts_num = [len(v_obj) for v_obj in verts]
+            edges_num = np.array([n-1 for n in verts_num])
+            total_num = sum(edges_num)
+            edges = np.zeros((total_num, 2), dtype=np.int64)
+            edge_indexes = [i for n in edges_num for i in range(n)]
+            for i, ei in enumerate(edge_indexes):
+                edges[i] = [ei, ei+1]
+            return edges, edges_num
+        else:
+            raise TypeError("Number of dimensions is not in range: 1 < n < 3")
+
+    @numba.njit
+    def f(a):
+        return sum(a)


### PR DESCRIPTION
This is attempt to bring raged arrays into Sverchok to improve vectorization performance and such data structures as polygons. The implementation uses [awkward arrays library](https://github.com/scikit-hep/awkward). In general it seems the library does not suit to our needs, it certainly solves some problems but brings others. But the library is good illustration of how to work with such data structure.

Main problem of awkward library is that all it's functions has [significant constant overhead](https://github.com/scikit-hep/awkward/discussions/2157). It means that even creating or handling empty arrays takes time. For example creating empty array takes 30us. For comparison creating numpy empty array takes 350ns what about 100 times faster. Overheads of other operations in awkward library takes about 100us. Implementation of several tens lines can have overhead of 10-20ms or even more.

Partly such problem can be solved by converting arrays into numpy arrays, solving a problem and converting them back into awkward arrays. The same can be done with numba implementation. Numba can takes awkward arrays directly without converting them into numpy arrays and can iterate over them. But it's impossible to generate awkward arrays inside numba. So you have to return several numpy arrays and convert them into awkward arrays with `ak.Array` and `ak.unflatten` commands. Also there is [inconvenience ](https://github.com/scikit-hep/awkward/discussions/2197)that with regular arrays numba will recompiled for each new shape of array, what also force using `ak.from_regular` before sending arrays into numba. So, overhead of preparing arrays will take about no less than 250us on my estimations. And this is too slow to update in real-time way more than 100 nodes.

The library probable works good for data analysis but does not work for real-time systems like our.

## What next

It's possible to implement our own data structure for raged arrays. For example data like this:

```py
data = [[1, 2, 3], [4, 5]]
```

Can be represented by two numpy arrays

```py
slices = np.array([0, 3, 5])
data = np.array([1, 2, 3, 4, 5])
```
And iterations over such data structure can look like this

```py
for slice in zip(slices[:-1], slices[1:]):
   for item in data[slice]:
        print(item)
```
And the work with such data structure should be done in numba I guess so it would be efficient.